### PR TITLE
Introduce product attributes

### DIFF
--- a/Drivers/ProductAttributeFieldDriver.cs
+++ b/Drivers/ProductAttributeFieldDriver.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Commerce.Fields;
+using OrchardCore.Commerce.Settings;
+using OrchardCore.Commerce.ViewModels;
+using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Display.Models;
+using OrchardCore.DisplayManagement.Views;
+
+namespace OrchardCore.Commerce.Drivers
+{
+    public abstract class ProductAttributeFieldDriver<TField, TFieldSettings> : ContentFieldDisplayDriver<TField>
+        where TField : ProductAttributeField, new()
+        where TFieldSettings : ProductAttributeFieldSettings
+    {
+        public ProductAttributeFieldDriver(
+            IStringLocalizer<ProductAttributeFieldDriver<TField, TFieldSettings>> localizer)
+        {
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; set; }
+
+        public override IDisplayResult Edit(TField field, BuildFieldEditorContext context)
+        {
+            return Initialize<EditProductAttributeFieldViewModel<TField, TFieldSettings>>(
+                GetEditorShapeType(context), model =>
+                {
+                    var settings = context.PartFieldDefinition.Settings.ToObject<TFieldSettings>();
+                    model.Field = field;
+                    model.Settings = settings;
+                    model.Part = context.ContentPart;
+                    model.PartFieldDefinition = context.PartFieldDefinition;
+                });
+        }
+    }
+
+    public class BooleanProductAttributeFieldDriver
+        : ProductAttributeFieldDriver<BooleanProductAttributeField, BooleanProductAttributeFieldSettings>
+    {
+        public BooleanProductAttributeFieldDriver(
+            IStringLocalizer<ProductAttributeFieldDriver<BooleanProductAttributeField, BooleanProductAttributeFieldSettings>> localizer)
+            : base(localizer) { }
+    }
+
+    public class NumericProductAttributeFieldDriver
+        : ProductAttributeFieldDriver<NumericProductAttributeField, NumericProductAttributeFieldSettings>
+    {
+        public NumericProductAttributeFieldDriver(
+            IStringLocalizer<ProductAttributeFieldDriver<NumericProductAttributeField, NumericProductAttributeFieldSettings>> localizer)
+            : base(localizer) { }
+    }
+
+    public class TextProductAttributeFieldDriver
+        : ProductAttributeFieldDriver<TextProductAttributeField, TextProductAttributeFieldSettings>
+    {
+        public TextProductAttributeFieldDriver(
+            IStringLocalizer<ProductAttributeFieldDriver<TextProductAttributeField, TextProductAttributeFieldSettings>> localizer)
+            : base(localizer) { }
+    }
+}

--- a/Fields/ProductAttributeField.cs
+++ b/Fields/ProductAttributeField.cs
@@ -1,0 +1,20 @@
+using OrchardCore.ContentManagement;
+
+namespace OrchardCore.Commerce.Fields
+{
+    /// <summary>
+    /// Adds the ability for a product to be modified with a set of attributes, in particular when
+    /// added to a shopping cart.
+    /// Examples of attributes can be shirt sizes (S, M, L, XL), dimensions, etc.
+    /// </summary>
+    public abstract class ProductAttributeField : ContentField
+    {
+        public ProductAttributeField() { }
+    }
+
+    public class BooleanProductAttributeField : ProductAttributeField { }
+
+    public class NumericProductAttributeField : ProductAttributeField { }
+
+    public class TextProductAttributeField : ProductAttributeField { }
+}

--- a/Settings/ProductAttributeFieldSettings.cs
+++ b/Settings/ProductAttributeFieldSettings.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public abstract class ProductAttributeFieldSettings
+    {
+        public string Hint { get; set; }
+    }
+
+    public abstract class ProductAttributeFieldSettings<T> : ProductAttributeFieldSettings
+    {
+        public T DefaultValue { get; set; }
+    }
+
+    public class BooleanProductAttributeFieldSettings : ProductAttributeFieldSettings<bool>
+    {
+        public string Label { get; set; }
+    }
+
+    public class NumericProductAttributeFieldSettings : ProductAttributeFieldSettings<decimal?>
+    {
+        public bool Required { get; set; }
+        public string Placeholder { get; set; }
+        public int DecimalPlaces { get; set; }
+        public decimal? Minimum { get; set; }
+        public decimal? Maximum { get; set; }
+    }
+
+    public class TextProductAttributeFieldSettings : ProductAttributeFieldSettings<string>
+    {
+        public bool Required { get; set; }
+        public string Placeholder { get; set; }
+        public string[] PredefinedValues { get; set; }
+        public bool RestrictToPredefinedValues { get; set; }
+        public bool MultipleValues { get; set; }
+    }
+}

--- a/Settings/ProductAttributeFieldSettingsDriver.cs
+++ b/Settings/ProductAttributeFieldSettingsDriver.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using OrchardCore.Commerce.Fields;
+using OrchardCore.Commerce.ViewModels;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Views;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public abstract class ProductAttributeFieldSettingsDriver<TFIeld, TSettings>
+        : ContentPartFieldDefinitionDisplayDriver<TFIeld>
+        where TFIeld : ProductAttributeField
+        where TSettings : ProductAttributeFieldSettings, new()
+    {
+        public override IDisplayResult Edit(ContentPartFieldDefinition partFieldDefinition)
+            => Initialize<TSettings>(typeof(TSettings).Name + "_Edit",
+                model => partFieldDefinition.Settings.Populate(model))
+            .Location("Content");
+
+        public override async Task<IDisplayResult> UpdateAsync(ContentPartFieldDefinition partFieldDefinition, UpdatePartFieldEditorContext context)
+        {
+            var model = new TSettings();
+            await context.Updater.TryUpdateModelAsync(model, Prefix);
+            context.Builder.MergeSettings(model);
+            return Edit(partFieldDefinition);
+        }
+    }
+
+    public class BooleanProductAttributeFieldSettingsDriver
+        : ProductAttributeFieldSettingsDriver<BooleanProductAttributeField, BooleanProductAttributeFieldSettings> {}
+
+    public class NumericProductAttributeFieldSettingsDriver
+        : ProductAttributeFieldSettingsDriver<NumericProductAttributeField, NumericProductAttributeFieldSettings> {}
+
+    public class TextProductAttributeFieldSettingsDriver
+        : ProductAttributeFieldSettingsDriver<TextProductAttributeField, TextProductAttributeFieldSettings> {
+        public override IDisplayResult Edit(ContentPartFieldDefinition partFieldDefinition)
+            => Initialize<TextProductAttributeSettingsViewModel>(nameof(TextProductAttributeFieldSettings) + "_Edit",
+                           viewModel =>
+                           {
+                               var model = new TextProductAttributeFieldSettings();
+                               partFieldDefinition.Settings.Populate(model);
+                               viewModel.Hint = model.Hint;
+                               viewModel.DefaultValue = model.DefaultValue;
+                               viewModel.Required = model.Required;
+                               viewModel.Placeholder = model.Placeholder;
+                               viewModel.PredefinedValues = model.PredefinedValues is object ? String.Join("\r\n", model.PredefinedValues) : "";
+                               viewModel.RestrictToPredefinedValues = model.RestrictToPredefinedValues;
+                               viewModel.MultipleValues = model.MultipleValues;
+                           }).Location("Content");
+
+        public override async Task<IDisplayResult> UpdateAsync(ContentPartFieldDefinition partFieldDefinition, UpdatePartFieldEditorContext context)
+        {
+            var viewModel = new TextProductAttributeSettingsViewModel();
+            await context.Updater.TryUpdateModelAsync(viewModel, Prefix);
+            context.Builder.MergeSettings(new TextProductAttributeFieldSettings {
+                Hint = viewModel.Hint,
+                DefaultValue = viewModel.DefaultValue,
+                Required = viewModel.Required,
+                Placeholder = viewModel.Placeholder,
+                RestrictToPredefinedValues = viewModel.RestrictToPredefinedValues,
+                MultipleValues = viewModel.MultipleValues
+            })
+            .WithSetting("PredefinedValues", viewModel.PredefinedValues
+                .Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(v => v.Trim())
+                .Where(v => !String.IsNullOrWhiteSpace(v))
+                .ToArray());
+            return Edit(partFieldDefinition);
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -2,15 +2,18 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Drivers;
+using OrchardCore.Commerce.Fields;
 using OrchardCore.Commerce.Handlers;
 using OrchardCore.Commerce.Indexes;
 using OrchardCore.Commerce.Migrations;
 using OrchardCore.Commerce.Models;
 using OrchardCore.Commerce.Money;
 using OrchardCore.Commerce.Services;
+using OrchardCore.Commerce.Settings;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
@@ -31,6 +34,16 @@ namespace OrchardCore.Commerce
             services.AddScoped<IContentAliasProvider, ProductPartContentAliasProvider>();
             services.AddScoped<IContentPartDisplayDriver, ProductPartDisplayDriver>();
             services.AddSingleton<ContentPart, ProductPart>();
+            // Attributes
+            services.AddSingleton<ContentField, BooleanProductAttributeField>();
+            services.AddScoped<IContentFieldDisplayDriver, BooleanProductAttributeFieldDriver>();
+            services.AddScoped<IContentPartFieldDefinitionDisplayDriver, BooleanProductAttributeFieldSettingsDriver>();
+            services.AddSingleton<ContentField, NumericProductAttributeField>();
+            services.AddScoped<IContentFieldDisplayDriver, NumericProductAttributeFieldDriver>();
+            services.AddScoped<IContentPartFieldDefinitionDisplayDriver, NumericProductAttributeFieldSettingsDriver>();
+            services.AddSingleton<ContentField, TextProductAttributeField>();
+            services.AddScoped<IContentFieldDisplayDriver, TextProductAttributeFieldDriver>();
+            services.AddScoped<IContentPartFieldDefinitionDisplayDriver, TextProductAttributeFieldSettingsDriver>();
             // Price
             services.AddScoped<IDataMigration, PriceMigrations>();
             services.AddScoped<IContentPartHandler, PricePartHandler>();

--- a/ViewModels/EditProductAttributeFieldViewModel.cs
+++ b/ViewModels/EditProductAttributeFieldViewModel.cs
@@ -1,0 +1,17 @@
+using OrchardCore.Commerce.Fields;
+using OrchardCore.Commerce.Settings;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata.Models;
+
+namespace OrchardCore.Commerce.ViewModels
+{
+    public class EditProductAttributeFieldViewModel<TField, TFieldSettings>
+        where TField : ProductAttributeField
+        where TFieldSettings : ProductAttributeFieldSettings
+    {
+        public TField Field { get; set; }
+        public TFieldSettings Settings { get; set; }
+        public ContentPart Part { get; set; }
+        public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    }
+}

--- a/ViewModels/TextProductAttributeSettingsViewModel.cs
+++ b/ViewModels/TextProductAttributeSettingsViewModel.cs
@@ -1,0 +1,13 @@
+namespace OrchardCore.Commerce.ViewModels
+{
+    public class TextProductAttributeSettingsViewModel
+    {
+        public string Hint { get; set; }
+        public string DefaultValue { get; set; }
+        public bool Required { get; set; }
+        public string Placeholder { get; set; }
+        public string PredefinedValues { get; set; }
+        public bool RestrictToPredefinedValues { get; set; }
+        public bool MultipleValues { get; set; }
+    }
+}

--- a/Views/BooleanProductAttributeFieldSettings.Edit.cshtml
+++ b/Views/BooleanProductAttributeFieldSettings.Edit.cshtml
@@ -1,0 +1,30 @@
+@model OrchardCore.Commerce.Settings.BooleanProductAttributeFieldSettings
+
+<fieldset class="form-group">
+    <div class="row col-md">
+        <label asp-for="Hint">@T["Hint"]</label>
+        <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
+        <span class="hint">@T["The description text to display for this attribute in the product page."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label asp-for="Label">@T["Label"]</label>
+        <input asp-for="Label" class="form-control" />
+        <span class="hint">@T["The text associated to the checkbox for this attribute in the product page."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label asp-for="Label">@T["Default value"]</label>
+    </div>
+    <div class="custom-control custom-checkbox">
+        <input asp-for="DefaultValue" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="DefaultValue">@T["On/Off"]</label>
+    </div>
+    <div class="row col-md">
+        <span class="hint">@T["The default value associated with this attribute."]</span>
+    </div>
+</fieldset>

--- a/Views/BooleanProductAttributeField_Edit.cshtml
+++ b/Views/BooleanProductAttributeField_Edit.cshtml
@@ -1,0 +1,17 @@
+@model OrchardCore.Commerce.ViewModels.EditProductAttributeFieldViewModel<BooleanProductAttributeField, BooleanProductAttributeFieldSettings>
+@using OrchardCore.ContentManagement.Metadata.Models
+@using OrchardCore.Commerce.Fields
+@using OrchardCore.Commerce.Settings
+@{
+    var settings = Model.Settings;
+    string name = Model.PartFieldDefinition.DisplayName();
+}
+
+    <fieldset class="form-group">
+        <label>@name @T["(Boolean product attribute)"]</label>
+        <ul>
+            <li class="hint">@T["Label: {0}", settings.Label]</li>
+            <li class="hint">@(settings.DefaultValue ? T["Default value: on"] : T["Default value: off"])</li>
+            <li class="hint">@T["Hint: {0}", settings.Hint]</li>
+        </ul>
+    </fieldset>

--- a/Views/NumericProductAttributeFieldSettings.Edit.cshtml
+++ b/Views/NumericProductAttributeFieldSettings.Edit.cshtml
@@ -1,0 +1,65 @@
+@model OrchardCore.Commerce.Settings.NumericProductAttributeFieldSettings
+@using System.Globalization
+
+@{
+    var step = Math.Pow(10, 0 - Model.DecimalPlaces);
+    var stepAttribute = step.ToString(CultureInfo.InvariantCulture);
+    string minimum = (Model.Minimum.HasValue) ? Math.Round(Model.Minimum.Value, Model.DecimalPlaces).ToString(CultureInfo.InvariantCulture) : "";
+    string maximum = (Model.Maximum.HasValue) ? Math.Round(Model.Maximum.Value, Model.DecimalPlaces).ToString(CultureInfo.InvariantCulture) : "";
+}
+
+<fieldset class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="Required" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="Required">@T["Required"]</label>
+        <span class="hint">@T["— Whether a value is required."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-md">
+        <label asp-for="Hint">@T["Hint"]</label>
+        <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
+        <span class="hint">@T["The hint text to display for this attribute in the product page."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-md">
+        <label for="Placeholder">@T["Watermark (placeholder)"]</label>
+        <input asp-for="Placeholder" type="text" class="form-control" />
+        <span class="hint">@T["A hint to display when the input is empty. (optional)"]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label for="DecimalPlaces">@T["Decimal places"]</label>
+        <input asp-for="DecimalPlaces" class="form-control" min="0" max="5" step="1" type="number" />
+        <span class="hint">@T["The number of digits after the decimal point."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label for="Minimum">@T["Minimum"]</label>
+        <input asp-for="Minimum" class="form-control" />
+        <span class="hint">@T["The minimum value allowed. (optional)"]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label for="Maximum">@T["Maximum"]</label>
+        <input asp-for="Maximum" class="form-control" />
+        <span class="hint">@T["The maximum value allowed. (optional)"]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label for="DefaultValue">@T["Default value"]</label>
+        <input asp-for="DefaultValue" class="form-control" min="@minimum" max="@maximum" step="@stepAttribute" type="number" />
+        <span class="hint">@T["The default value. (optional)"]</span>
+    </div>
+</fieldset>

--- a/Views/NumericProductAttributeField_Edit.cshtml
+++ b/Views/NumericProductAttributeField_Edit.cshtml
@@ -1,0 +1,30 @@
+@model OrchardCore.Commerce.ViewModels.EditProductAttributeFieldViewModel<NumericProductAttributeField, NumericProductAttributeFieldSettings>
+@using OrchardCore.ContentManagement.Metadata.Models
+@using OrchardCore.Commerce.Fields
+@using OrchardCore.Commerce.Settings
+@{
+    var settings = Model.Settings;
+    string name = Model.PartFieldDefinition.DisplayName();
+}
+
+<fieldset class="form-group">
+    <label>@name @T["(Numeric product attribute)"]</label>
+    <ul>
+        @if (settings.Required) {
+            <li class="hint">@T["Required"]</li>
+        }
+        <li class="hint">@T["Decimal places: {0}", settings.DecimalPlaces]</li>
+        @if (settings.DefaultValue.HasValue) {
+            <li class="hint">@T["Default value: {0}", settings.DefaultValue.Value]</li>
+        }
+        @if (settings.Minimum.HasValue && settings.Maximum.HasValue) {
+            <li class="hint">@T["Value must be between {0} and {1}", settings.Minimum.Value, settings.Maximum.Value]</li>
+        } else if (settings.Minimum.HasValue) {
+            <li class="hint">@T["Minimum value: {0}", settings.Minimum.Value]</li>
+        } else if (settings.Maximum.HasValue) {
+            <li class="hint">@T["Maximum value: {0}", settings.Maximum.Value]</li>
+        }
+        <li class="hint">@T["Placeholder: {0}", settings.Placeholder]</li>
+        <li class="hint">@T["Hint: {0}", settings.Hint]</li>
+    </ul>
+</fieldset>

--- a/Views/TextProductAttributeFieldSettings.Edit.cshtml
+++ b/Views/TextProductAttributeFieldSettings.Edit.cshtml
@@ -1,0 +1,57 @@
+@model OrchardCore.Commerce.ViewModels.TextProductAttributeSettingsViewModel
+
+<fieldset class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="Required" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="Required">@T["Required"]</label>
+        <span class="hint">@T["— Whether a value is required."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm-6">
+        <label asp-for="Hint">@T["Hint"]</label>
+        <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
+        <span class="hint">@T["The hint text to display for this attribute in the product page."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-md">
+        <label for="Placeholder">@T["Watermark (placeholder)"]</label>
+        <input asp-for="Placeholder" type="text" class="form-control" />
+        <span class="hint">@T["A hint to display when the input is empty. (optional)"]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm-6">
+        <label for="PredefinedValues">@T["Predefined values"]</label>
+        <textarea asp-for="PredefinedValues" cols="60" rows="8" class="form-control"></textarea>
+        <span class="hint">@T["The set of suggested or allowed values. Enter one value per line."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="RestrictToPredefinedValues" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="RestrictToPredefinedValues">@T["Restrict to predefined values"]</label>
+        <span class="hint">@T["— Whether values should be restricted to the set of predefined values."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input asp-for="MultipleValues" type="checkbox" class="custom-control-input">
+        <label class="custom-control-label" asp-for="MultipleValues">@T["Multiple values"]</label>
+        <span class="hint">@T["— Whether multiple values can be selected."]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group">
+    <div class="row col-sm">
+        <label for="DefaultValue">@T["Default value"]</label>
+        <input asp-for="DefaultValue" class="form-control" type="text" />
+        <span class="hint">@T["The default value. (optional)"]</span>
+    </div>
+</fieldset>

--- a/Views/TextProductAttributeField_Edit.cshtml
+++ b/Views/TextProductAttributeField_Edit.cshtml
@@ -1,0 +1,30 @@
+@model OrchardCore.Commerce.ViewModels.EditProductAttributeFieldViewModel<TextProductAttributeField, TextProductAttributeFieldSettings>
+@using OrchardCore.ContentManagement.Metadata.Models
+@using OrchardCore.Commerce.Fields
+@using OrchardCore.Commerce.Settings
+@{
+    var settings = Model.Settings;
+    string name = Model.PartFieldDefinition.DisplayName();
+}
+
+<fieldset class="form-group">
+    <label>@name @T["(Text product attribute)"]</label>
+    <ul>
+        @if (settings.Required) {
+            <li class="hint">@T["Required"]</li>
+        }
+        @if ((settings.PredefinedValues is object) && (settings.PredefinedValues.Length > 0)) {
+            <li class="hint">@T["Predefined values: {0}", string.Join(", ", settings.PredefinedValues)]</li>
+            @if (settings.RestrictToPredefinedValues) {
+                <li class="hint">@T["Choice is restricted to predefined values."]</li>
+            } else {
+                <li class="hint">@T["The user may enter a value that is not one of the predefined values."]</li>
+            }
+            @if (settings.MultipleValues) {
+                <li class="hint">@T["The user may select more than one value."]</li>
+            }
+        }
+        <li class="hint">@T["Placeholder: {0}", settings.Placeholder]</li>
+        <li class="hint">@T["Hint: {0}", settings.Hint]</li>
+    </ul>
+</fieldset>


### PR DESCRIPTION
Product attributes are defined as fields that usually have nothing to edit in the product editor. The parameters of the attributes are usually set-up at the content type definition level, as settings of the fields.

Built-in product attributes are Boolean, numeric, and text (which includes predefined values, and thus can handle enums, flags, and combos). This should be enough for most cases, but is, as usual, extensible.

The front-end for those new fields will be introduced with the shopping cart: each attribute will participate as adding information to the "add to cart" action. For example, adding two shirts of size M.