### PR TITLE
Model complex product. (Color/Size)

### DIFF
--- a/Recipes/ComplexProduct.recipe.json
+++ b/Recipes/ComplexProduct.recipe.json
@@ -1,0 +1,306 @@
+{
+  "name": "ComplexProduct",
+  "displayName": "ComplexProduct",
+  "description": "Creates a Product content type with a Price Part and experimental SizeCurve content types.",
+  "author": "The Orchard Team",
+  "website": "https://orchardproject.net",
+  "version": "2.0",
+  "issetuprecipe": false,
+  "categories": [ "commerce" ],
+  "tags": [ "complexproduct" ],
+  "steps": [
+    {
+      "name": "feature",
+      "disable": [],
+      "enable": [
+        "OrchardCore.Autoroute",
+        "OrchardCore.Html",
+        "OrchardCore.Title",
+        "OrchardCore.Commerce"
+      ]
+    },
+    {
+      "name": "ContentDefinition",
+      "ContentTypes": [
+        {
+          "Name": "SizeCurve",
+          "DisplayName": "SizeCurve",
+          "Settings": {
+            "Creatable": "True",
+            "Draftable": "True",
+            "Versionable": "True",
+            "Listable": "True",
+            "Securable": "True",
+            "Stereotype": null
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "SizeCurve",
+              "Name": "SizeCurve",
+              "Settings": {
+                "Position": "2"
+              }
+            },
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "Position": "0"
+              }
+            },
+            {
+              "PartName": "BagPart",
+              "Name": "BagPart",
+              "Settings": {
+                "DisplayName": "Bag",
+                "Description": "Provides a collection behavior for your content item.",
+                "Editor": null,
+                "ContainedContentTypes": [
+                  "Size"
+                ],
+                "DisplayType": null,
+                "Position": "1"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Size",
+          "DisplayName": "Size",
+          "Settings": {
+            "Creatable": "True",
+            "Draftable": "True",
+            "Versionable": "True",
+            "Listable": "True",
+            "Securable": "True",
+            "Stereotype": null
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "Size",
+              "Name": "Size",
+              "Settings": {
+                "Position": "1"
+              }
+            },
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "Position": "0"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "ComplexProduct",
+          "DisplayName": "ComplexProduct",
+          "Settings": {
+            "Creatable": "True",
+            "Draftable": "True",
+            "Versionable": "True",
+            "Listable": "True",
+            "Securable": "True",
+            "Stereotype": null
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "ComplexProduct",
+              "Name": "ComplexProduct",
+              "Settings": {
+                "Position": "1"
+              }
+            },
+            {
+              "PartName": "PricePart",
+              "Name": "PricePart",
+              "Settings": {
+                "Position": "2"
+              }
+            },
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "Position": "0"
+              }
+            },
+            {
+              "PartName": "BagPart",
+              "Name": "BagPart",
+              "Settings": {
+                "DisplayName": "Bag",
+                "Description": "Provides a collection behavior for your content item.",
+                "Editor": null,
+                "ContainedContentTypes": [
+                  "ComplexProductItem"
+                ],
+                "DisplayType": null,
+                "Position": "3"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "SizeCurveWithContentPicker",
+          "DisplayName": "SizeCurveWithContentPicker",
+          "Settings": {
+            "Creatable": "True",
+            "Draftable": "True",
+            "Versionable": "True",
+            "Listable": "True",
+            "Securable": "True",
+            "Stereotype": null
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "SizeCurveWithContentPicker",
+              "Name": "SizeCurveWithContentPicker",
+              "Settings": {
+                "Position": "1"
+              }
+            },
+            {
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "Position": "0"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "ComplexProductItem",
+          "DisplayName": "ComplexProductItem",
+          "Settings": {
+            "Creatable": "True",
+            "Draftable": "True",
+            "Versionable": "True",
+            "Listable": "True",
+            "Securable": "True",
+            "Stereotype": null
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "ComplexProductItem",
+              "Name": "ComplexProductItem",
+              "Settings": {
+                "Position": "1"
+              }
+            },
+            {
+              "PartName": "ProductPart",
+              "Name": "ProductPart",
+              "Settings": {
+                "Position": "0"
+              }
+            }
+          ]
+        }
+      ],
+      "ContentParts": [
+        {
+          "Name": "ComplexProduct",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "ContentPickerField",
+              "Name": "SizeCurve",
+              "Settings": {
+                "DisplayName": "SizeCurve",
+                "Editor": null,
+                "DisplayMode": null,
+                "Hint": null,
+                "Required": false,
+                "Multiple": false,
+                "DisplayedContentTypes": [
+                  "SizeCurve"
+                ],
+                "Position": "2"
+              }
+            },
+            {
+              "FieldName": "HtmlField",
+              "Name": "Description",
+              "Settings": {
+                "DisplayName": "Description",
+                "Editor": null,
+                "DisplayMode": null,
+                "Hint": null,
+                "Position": "1"
+              }
+            },
+            {
+              "FieldName": "ContentPickerField",
+              "Name": "SizeCurveWithContentPicker",
+              "Settings": {
+                "DisplayName": "SizeCurveWithContentPicker",
+                "Editor": null,
+                "DisplayMode": null,
+                "Hint": null,
+                "Required": false,
+                "Multiple": false,
+                "DisplayedContentTypes": [
+                  "SizeCurveWithContentPicker"
+                ],
+                "Position": "3"
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "ModelNumber",
+              "Settings": {
+                "DisplayName": "Model number",
+                "Position": "0"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "SizeCurveWithContentPicker",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "ContentPickerField",
+              "Name": "Size",
+              "Settings": {
+                "DisplayName": "Size",
+                "Editor": null,
+                "DisplayMode": null,
+                "Hint": null,
+                "Required": true,
+                "Multiple": true,
+                "DisplayedContentTypes": [
+                  "Size"
+                ],
+                "Position": "0"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "ComplexProductItem",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "ContentPickerField",
+              "Name": "Size",
+              "Settings": {
+                "DisplayName": "Size",
+                "Editor": null,
+                "DisplayMode": null,
+                "Hint": null,
+                "Required": true,
+                "Multiple": false,
+                "DisplayedContentTypes": [
+                  "Size"
+                ],
+                "Position": "0"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I've been trying to model different kind of products and are thinking of a complex product that can contain many variants of a product.

The idea is that when creating a product, it is given a name, description, price and other common data. Some of the common data could be overridden in the data for the variant of the product.

Each variant of the product is represented as a sub product with the unique information for that variant. The Product (SKU) part is connected to each variant of the product. Could be automatically generated by combining some data. For example: ProductId, ColorId and SizeId. The Product (SKU) will be the unique identifier connected to inventory, shopping cart etc. The other attributes (for example color/size) would only be for information/presentation and not part of the identifier. 

For a simple product that have no variants the Product (SKU) part would be connected directly to the base product. Inventory, shopping cart etc. would have the same unique identifier to the product sold.

In combination with for example a list of different colors the subitems could be generated automatically. A nice way to render the data would be in a grid where for example stock data for each variant can be displayed/modified in an admin part of the site.

**SizeCurve**
Ordering in the size curve should be considered when rendering data on the admin (product maintenance)/frontend (product pages).

**Sample content items in the recipe**
The attached recipe contains the following content types:
- ComplexProduct
- ComplexProductItem (variant of the product, for example: color/size combination)
- Size
- SizeCurve (using a bag part to describe the available sizes)
- SizeCurveWithContentPicker (SizeCurve where predefined sizes (Size) can be selected to be available in the size curve.

The content items in the recipe are minimal to discuss the idea. For example: Size might need an id and sort order.

**Create a product**
1. Create some sizes. For example: S, M, L and XL
2. Create a size curve. For example: S-XL.
3. Add the sizes in the size curve.
4. Create a ComplexProduct.

It doesn't render correctly on the frontend when the Product (SKU) is attached to the sub product, but it't possible to create content items in the admin.

The screenshot below shows a ComplexProduct with one variant (size S) added manually.

![image](https://user-images.githubusercontent.com/49494169/56534604-5344f180-655a-11e9-9935-cfbe35dd55b1.png)

My main goal with this is to get some feedback/discuss the ideas. I think it's possible to model as content types but will require some development of new editors for the UI. Some logic for generating variants automatically will also have to be considered.