### PR TITLE
Currency serialization fixes

### DIFF
--- a/Drivers/PricePartDisplayDriver.cs
+++ b/Drivers/PricePartDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Money;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
 using OrchardCore.Commerce.ViewModels;
@@ -48,7 +49,7 @@ namespace OrchardCore.Commerce.Drivers
 
             model.Price = part.Price;
             model.PriceValue = part.Price.Value;
-            model.PriceCurrency = part.Price.Currency?.CurrencyIsoCode ?? _moneyService.DefaultCurrency.CurrencyIsoCode;
+            model.PriceCurrency = part.Price.Currency == Currency.UnspecifiedCurrency ? _moneyService.DefaultCurrency.CurrencyIsoCode : part.Price.Currency.CurrencyIsoCode;
             model.PricePart = part;
             model.Currencies = _moneyService.Currencies;
 

--- a/MoneyDataType/LegacyAmountConverter.cs
+++ b/MoneyDataType/LegacyAmountConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Money.Abstractions;
 
 namespace Money.Serialization
@@ -21,7 +21,6 @@ namespace Money.Serialization
             string symbol = null;
             string iso = null;
             int? dec = null;
-            bool unknown = false;
 
             while (reader.Read())
             {
@@ -40,25 +39,23 @@ namespace Money.Serialization
 
                     case Name:
                         name = reader.ReadAsString();
-                        unknown = true;
                         break;
                     case Symbol:
                         symbol = reader.ReadAsString();
-                        unknown = true;
                         break;
                     case Iso:
                         iso = reader.ReadAsString();
-                        unknown = true;
                         break;
                     case Dec:
                         dec = reader.ReadAsInt32();
-                        unknown = true;
                         break;
                 }
             }
 
-            if (unknown)
+            if (!Currency.IsKnownCurrency(currency.CurrencyIsoCode))
+            {
                 currency = new Currency(name, symbol, iso, dec.GetValueOrDefault(2));
+            }
 
             if (currency is null)
                 throw new InvalidOperationException("Invalid amount format. Must include a currency");

--- a/Settings/CommerceSettingsConfiguration.cs
+++ b/Settings/CommerceSettingsConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public class CommerceSettingsConfiguration : IConfigureOptions<CommerceSettings>
+    {
+        private readonly ISiteService _site;
+        private readonly ILogger<CommerceSettingsConfiguration> _logger;
+
+        public CommerceSettingsConfiguration(
+            ISiteService site,
+            ILogger<CommerceSettingsConfiguration> logger)
+        {
+            _site = site;
+            _logger = logger;
+        }
+
+        public void Configure(CommerceSettings options)
+        {
+            var settings = _site.GetSiteSettingsAsync()
+                .GetAwaiter().GetResult()
+                .As<CommerceSettings>();
+
+            options.DefaultCurrency = settings.DefaultCurrency;
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Money;
 using Money.Abstractions;
 using OrchardCore.Commerce.Abstractions;
@@ -75,6 +76,7 @@ namespace OrchardCore.Commerce
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddScoped<IDisplayDriver<ISite>, CommerceSettingsDisplayDriver>();
             services.AddScoped<INavigationProvider, AdminMenu>();
+            services.AddTransient<IConfigureOptions<CommerceSettings>, CommerceSettingsConfiguration>();
         }
     }
 


### PR DESCRIPTION
Fix reading known currencies and add back initialization of default currency configured in settings.

I've only done tests with the PricePart, The changes are not verified with the PriceVariantsPart.

The main issue was that when a known currency was saved only the CurrencyIsoCode is saved. When reading it back the missing values resulted in it being handled as unknown.

Added back the CommerceSettingsConfiguration so that the default currency configured for the site is taken into consideration.