### PR TITLE
Default currency settings formatting

### DIFF
--- a/Abstractions/IPredefinedValuesProductAttributeFieldSettings.cs
+++ b/Abstractions/IPredefinedValuesProductAttributeFieldSettings.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using OrchardCore.ContentManagement;
-using OrchardCore.ContentManagement.Metadata.Models;
 
 namespace OrchardCore.Commerce.Abstractions
 {

--- a/Drivers/ProductPartDisplayDriver.cs
+++ b/Drivers/ProductPartDisplayDriver.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;

--- a/Services/ShoppingCartHelpers.cs
+++ b/Services/ShoppingCartHelpers.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Money;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
 using OrchardCore.Commerce.ProductAttributeValues;

--- a/Settings/CommerceSettingsDisplayDriver.cs
+++ b/Settings/CommerceSettingsDisplayDriver.cs
@@ -55,7 +55,11 @@ namespace OrchardCore.Commerce.Settings
                 Initialize<CommerceSettingsViewModel>("CommerceSettings_Edit", model =>
                 {
                     model.DefaultCurrency = section.DefaultCurrency ?? _moneyService.DefaultCurrency.CurrencyIsoCode;
-                    model.Currencies = _moneyService.Currencies.Select(c => new SelectListItem(c.CurrencyIsoCode, S[c.EnglishName]));
+                    model.Currencies = _moneyService.Currencies
+                        .OrderBy(c => c.CurrencyIsoCode)
+                        .Select(c => new SelectListItem(
+                            c.CurrencyIsoCode,
+                            $"{c.CurrencyIsoCode} {c.Symbol} - {S[c.EnglishName]}"));
                 }).Location("Content:5").OnGroup(GroupId)
             };
 


### PR DESCRIPTION
Adding the symbol and ISO code in the drop-down so currencies are easily identified even without a translation of the currency name.

![image](https://user-images.githubusercontent.com/1165609/74214385-11ed1200-4c52-11ea-9d77-2b31a18ce36c.png)
