### PR TITLE
PricePart currency configuration.

### DIFF
--- a/Drivers/PricePartDisplayDriver.cs
+++ b/Drivers/PricePartDisplayDriver.cs
@@ -66,15 +66,11 @@ namespace OrchardCore.Commerce.Drivers
 
             switch (part.CurrencySelectionMode)
             {
-                case CurrencySelectionModes.AllCurrencies:
-                    currencySelectionList = _moneyService.Currencies;
-                    break;
-
-                case CurrencySelectionModes.DefaultCurrency:
+                case CurrencySelectionModeEnum.DefaultCurrency:
                     currencySelectionList = new List<ICurrency>() { _moneyService.DefaultCurrency };
                     break;
 
-                case CurrencySelectionModes.SpecificCurrency:
+                case CurrencySelectionModeEnum.SpecificCurrency:
                     currencySelectionList = new List<ICurrency>() { _moneyService.GetCurrency(part.CurrencyIsoCode) };
                     break;
 

--- a/Drivers/PricePartDisplayDriver.cs
+++ b/Drivers/PricePartDisplayDriver.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Money;
+using Money.Abstractions;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
+using OrchardCore.Commerce.Settings;
 using OrchardCore.Commerce.ViewModels;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.DisplayManagement.ModelBinding;
@@ -51,9 +54,37 @@ namespace OrchardCore.Commerce.Drivers
             model.PriceValue = part.Price.Value;
             model.PriceCurrency = part.Price.Currency == Currency.UnspecifiedCurrency ? _moneyService.DefaultCurrency.CurrencyIsoCode : part.Price.Currency.CurrencyIsoCode;
             model.PricePart = part;
-            model.Currencies = _moneyService.Currencies;
+
+            model.Currencies = GetCurrencySelectionList(part);
 
             return Task.CompletedTask;
+        }
+
+        private IEnumerable<ICurrency> GetCurrencySelectionList(PricePart part)
+        {
+            IEnumerable<ICurrency> currencySelectionList;
+
+            switch (part.CurrencySelectionMode)
+            {
+                case CurrencySelectionModes.AllCurrencies:
+                    currencySelectionList = _moneyService.Currencies;
+                    break;
+
+                case CurrencySelectionModes.DefaultCurrency:
+                    currencySelectionList = new List<ICurrency>() { _moneyService.DefaultCurrency };
+                    break;
+
+                case CurrencySelectionModes.SpecificCurrency:
+                    currencySelectionList = new List<ICurrency>() { _moneyService.GetCurrency(part.CurrencyIsoCode) };
+                    break;
+
+                default:
+                    // As a fallback show all currencies.
+                    currencySelectionList = _moneyService.Currencies;
+                    break;
+            }
+
+            return currencySelectionList;
         }
     }
 }

--- a/Handlers/PricePartHandler.cs
+++ b/Handlers/PricePartHandler.cs
@@ -31,22 +31,20 @@ namespace OrchardCore.Commerce.Handlers
         {
             part.Price = _moneyService.EnsureCurrency(part.Price);
 
-            GetCurrencySelectionMode(part);
-
             return base.LoadingAsync(context, part);
         }
 
         private void GetCurrencySelectionMode(PricePart part)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.PartDefinition.Name, "PricePart"));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => x.PartDefinition.Name == nameof(PricePart));
             var currencySelectionMode = contentTypePartDefinition.GetSettings<PricePartSettings>().CurrencySelectionMode;
 
             part.CurrencySelectionMode = currencySelectionMode;
 
-            if (currencySelectionMode == CurrencySelectionModes.SpecificCurrency)
+            if (currencySelectionMode == CurrencySelectionModeEnum.SpecificCurrency)
             {
-                part.CurrencyIsoCode = contentTypePartDefinition.GetSettings<PricePartSettings>().CurrencyIsoCode;
+                part.CurrencyIsoCode = contentTypePartDefinition.GetSettings<PricePartSettings>().SpecificCurrencyIsoCode;
             }
         }
     }

--- a/Handlers/PricePartHandler.cs
+++ b/Handlers/PricePartHandler.cs
@@ -1,23 +1,53 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
+using OrchardCore.Commerce.Settings;
 using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentManagement.Metadata;
 
 namespace OrchardCore.Commerce.Handlers
 {
     public class PricePartHandler : ContentPartHandler<PricePart>
     {
-        private IMoneyService _moneyService;
+        private readonly IMoneyService _moneyService;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
 
-        public PricePartHandler(IMoneyService moneyService)
+        public PricePartHandler(IMoneyService moneyService, IContentDefinitionManager contentDefinitionManager)
         {
             _moneyService = moneyService;
+            _contentDefinitionManager = contentDefinitionManager;
+        }
+
+        public override Task InitializingAsync(InitializingContentContext context, PricePart part)
+        {
+            GetCurrencySelectionMode(part);
+
+            return base.InitializingAsync(context, part);
         }
 
         public override Task LoadingAsync(LoadContentContext context, PricePart part)
         {
             part.Price = _moneyService.EnsureCurrency(part.Price);
+
+            GetCurrencySelectionMode(part);
+
             return base.LoadingAsync(context, part);
+        }
+
+        private void GetCurrencySelectionMode(PricePart part)
+        {
+            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.PartDefinition.Name, "PricePart"));
+            var currencySelectionMode = contentTypePartDefinition.GetSettings<PricePartSettings>().CurrencySelectionMode;
+
+            part.CurrencySelectionMode = currencySelectionMode;
+
+            if (currencySelectionMode == CurrencySelectionModes.SpecificCurrency)
+            {
+                part.CurrencyIsoCode = contentTypePartDefinition.GetSettings<PricePartSettings>().CurrencyIsoCode;
+            }
         }
     }
 }

--- a/Models/PricePart.cs
+++ b/Models/PricePart.cs
@@ -1,4 +1,5 @@
 using Money;
+using OrchardCore.Commerce.Settings;
 using OrchardCore.ContentManagement;
 
 namespace OrchardCore.Commerce.Models
@@ -10,7 +11,7 @@ namespace OrchardCore.Commerce.Models
     {
         public Amount Price { get; set; } = new Amount(0, Currency.UnspecifiedCurrency);
 
-        public string CurrencySelectionMode { get; set; }
+        public CurrencySelectionModeEnum CurrencySelectionMode { get; set; }
         public string CurrencyIsoCode { get; set; }
     }
 }

--- a/Models/PricePart.cs
+++ b/Models/PricePart.cs
@@ -9,5 +9,8 @@ namespace OrchardCore.Commerce.Models
     public class PricePart : ContentPart
     {
         public Amount Price { get; set; } = new Amount(0, Currency.UnspecifiedCurrency);
+
+        public string CurrencySelectionMode { get; set; }
+        public string CurrencyIsoCode { get; set; }
     }
 }

--- a/Settings/CurrencySelectionModeEnum.cs
+++ b/Settings/CurrencySelectionModeEnum.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public enum CurrencySelectionModeEnum
+    {
+        AllCurrencies,
+        DefaultCurrency,
+        SpecificCurrency
+    }
+}

--- a/Settings/PricePartSettings.cs
+++ b/Settings/PricePartSettings.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public class CurrencySelectionModes
+    {
+        public const string AllCurrencies = "AllCurrencies";
+        public const string DefaultCurrency = "DefaultCurrency";
+        public const string SpecificCurrency = "SpecificCurrency";
+    }
+
+    public class PricePartSettings
+    {
+        public string CurrencySelectionMode { get; set; }
+        public string CurrencyIsoCode { get; set; }
+    }
+}

--- a/Settings/PricePartSettings.cs
+++ b/Settings/PricePartSettings.cs
@@ -1,19 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace OrchardCore.Commerce.Settings
 {
-    public class CurrencySelectionModes
-    {
-        public const string AllCurrencies = "AllCurrencies";
-        public const string DefaultCurrency = "DefaultCurrency";
-        public const string SpecificCurrency = "SpecificCurrency";
-    }
-
+    [JsonObject]
     public class PricePartSettings
     {
-        public string CurrencySelectionMode { get; set; }
-        public string CurrencyIsoCode { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public CurrencySelectionModeEnum CurrencySelectionMode { get; set; }
+        public string SpecificCurrencyIsoCode { get; set; }
     }
 }

--- a/Settings/PricePartSettingsDisplayDriver.cs
+++ b/Settings/PricePartSettingsDisplayDriver.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Commerce.Abstractions;
+using OrchardCore.Commerce.Models;
+using OrchardCore.Commerce.ViewModels;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Views;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public class PricePartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
+    {
+        private readonly IStringLocalizer<PricePartSettingsDisplayDriver> S;
+        private readonly IMoneyService _moneyService;
+
+        public PricePartSettingsDisplayDriver(IStringLocalizer<PricePartSettingsDisplayDriver> localizer, IMoneyService moneyService)
+        {
+            S = localizer;
+            _moneyService = moneyService;
+        }
+
+        public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        {
+            if (!String.Equals(nameof(PricePart), contentTypePartDefinition.PartDefinition.Name))
+            {
+                return null;
+            }
+
+            return Initialize<PricePartSettingsViewModel>("PricePartSettings_Edit", model =>
+            {
+                var settings = contentTypePartDefinition.GetSettings<PricePartSettings>();
+
+                model.CurrencySelectionMode = settings.CurrencySelectionMode;
+                model.CurrencySelectionModes = new List<SelectListItem>()
+                {
+                    new SelectListItem(CurrencySelectionModes.AllCurrencies, S["All Currencies"]),
+                    new SelectListItem(CurrencySelectionModes.DefaultCurrency, S["Default Currency"]),
+
+                    // TODO: MP - Fix view so that currency selector dropdown is only visible when Specific Currency is selected.
+                    //new SelectListItem(CurrencySelectionModes.SpecificCurrency, S["Specific Currency"])
+                };
+                model.CurrencyIsoCode = settings.CurrencyIsoCode;
+                model.Currencies = _moneyService.Currencies
+                        .OrderBy(c => c.CurrencyIsoCode)
+                        .Select(c => new SelectListItem(
+                            c.CurrencyIsoCode,
+                            $"{c.CurrencyIsoCode} {c.Symbol} - {S[c.EnglishName]}"));
+            }).Location("Content");
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
+        {
+            if (!String.Equals(nameof(PricePart), contentTypePartDefinition.PartDefinition.Name))
+            {
+                return null;
+            }
+
+            var model = new PricePartSettingsViewModel();
+
+            await context.Updater.TryUpdateModelAsync(model, Prefix,
+                m => m.CurrencySelectionMode,
+                m => m.CurrencyIsoCode);
+
+            context.Builder.WithSettings(new PricePartSettings
+            {
+                CurrencySelectionMode = model.CurrencySelectionMode,
+                CurrencyIsoCode =
+                    model.CurrencySelectionMode == CurrencySelectionModes.SpecificCurrency
+                        ? model.CurrencyIsoCode : null
+            });
+
+            return Edit(contentTypePartDefinition, context.Updater);
+        }
+    }
+}

--- a/Settings/PricePartSettingsDisplayDriver.cs
+++ b/Settings/PricePartSettingsDisplayDriver.cs
@@ -39,13 +39,11 @@ namespace OrchardCore.Commerce.Settings
                 model.CurrencySelectionMode = settings.CurrencySelectionMode;
                 model.CurrencySelectionModes = new List<SelectListItem>()
                 {
-                    new SelectListItem(CurrencySelectionModes.AllCurrencies, S["All Currencies"]),
-                    new SelectListItem(CurrencySelectionModes.DefaultCurrency, S["Default Currency"]),
-
-                    // TODO: MP - Fix view so that currency selector dropdown is only visible when Specific Currency is selected.
-                    //new SelectListItem(CurrencySelectionModes.SpecificCurrency, S["Specific Currency"])
+                    new SelectListItem(CurrencySelectionModeEnum.AllCurrencies.ToString(), S["All Currencies"]),
+                    new SelectListItem(CurrencySelectionModeEnum.DefaultCurrency.ToString(), S["Default Currency"]),
+                    new SelectListItem(CurrencySelectionModeEnum.SpecificCurrency.ToString(), S["Specific Currency"])
                 };
-                model.CurrencyIsoCode = settings.CurrencyIsoCode;
+                model.SpecificCurrencyIsoCode = settings.SpecificCurrencyIsoCode;
                 model.Currencies = _moneyService.Currencies
                         .OrderBy(c => c.CurrencyIsoCode)
                         .Select(c => new SelectListItem(
@@ -65,14 +63,14 @@ namespace OrchardCore.Commerce.Settings
 
             await context.Updater.TryUpdateModelAsync(model, Prefix,
                 m => m.CurrencySelectionMode,
-                m => m.CurrencyIsoCode);
+                m => m.SpecificCurrencyIsoCode);
 
             context.Builder.WithSettings(new PricePartSettings
             {
                 CurrencySelectionMode = model.CurrencySelectionMode,
-                CurrencyIsoCode =
-                    model.CurrencySelectionMode == CurrencySelectionModes.SpecificCurrency
-                        ? model.CurrencyIsoCode : null
+                SpecificCurrencyIsoCode =
+                    model.CurrencySelectionMode == CurrencySelectionModeEnum.SpecificCurrency
+                        ? model.SpecificCurrencyIsoCode : null
             });
 
             return Edit(contentTypePartDefinition, context.Updater);

--- a/Startup.cs
+++ b/Startup.cs
@@ -56,6 +56,7 @@ namespace OrchardCore.Commerce
             services.AddScoped<IDataMigration, PriceMigrations>();
             services.AddScoped<IContentPartHandler, PricePartHandler>();
             services.AddScoped<IContentPartDisplayDriver, PricePartDisplayDriver>();
+            services.AddScoped<IContentTypePartDefinitionDisplayDriver, PricePartSettingsDisplayDriver>();
             services.AddContentPart<PricePart>();
             services.AddScoped<IPriceProvider, PriceProvider>();
             services.AddScoped<IPriceService, PriceService>();

--- a/ViewModels/PricePartSettingsViewModel.cs
+++ b/ViewModels/PricePartSettingsViewModel.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using OrchardCore.Commerce.Settings;
@@ -9,12 +7,14 @@ namespace OrchardCore.Commerce.ViewModels
 {
     public class PricePartSettingsViewModel
     {
-        public string CurrencySelectionMode { get; set; }
-        public string CurrencyIsoCode { get; set; }
+        public CurrencySelectionModeEnum CurrencySelectionMode { get; set; }
+        public string SpecificCurrencyIsoCode { get; set; }
 
         public IEnumerable<SelectListItem> CurrencySelectionModes { get; set; }
 
         public IEnumerable<SelectListItem> Currencies { get; set; }
+
+        public CurrencySelectionModeEnum SingleSelectionModeEditor => CurrencySelectionModeEnum.SpecificCurrency;
 
         [BindNever]
         public PricePartSettings PricePartSettings { get; set; }

--- a/ViewModels/PricePartSettingsViewModel.cs
+++ b/ViewModels/PricePartSettingsViewModel.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using OrchardCore.Commerce.Settings;
+
+namespace OrchardCore.Commerce.ViewModels
+{
+    public class PricePartSettingsViewModel
+    {
+        public string CurrencySelectionMode { get; set; }
+        public string CurrencyIsoCode { get; set; }
+
+        public IEnumerable<SelectListItem> CurrencySelectionModes { get; set; }
+
+        public IEnumerable<SelectListItem> Currencies { get; set; }
+
+        [BindNever]
+        public PricePartSettings PricePartSettings { get; set; }
+    }
+}

--- a/Views/PricePartSettings.Edit.cshtml
+++ b/Views/PricePartSettings.Edit.cshtml
@@ -1,0 +1,27 @@
+@model PricePartSettingsViewModel
+
+    <fieldset class="form-group" asp-validation-class-for="PricePartSettings">
+        <label asp-for="CurrencySelectionMode">@T["Currency selection mode"]</label>
+
+        <div class="input-group">
+            <div class="input-group-append">
+                <select asp-for="CurrencySelectionMode"
+                        asp-items="@(new SelectList(Model.CurrencySelectionModes, "Text", "Value"))"></select>
+            </div>
+        </div>
+
+        <span class="hint">@T["Specifies the currency configuration for this PricePart."]</span>
+
+        @* TODO: MP - Enable the block below when conditional display is done. *@
+            
+        @*<label asp-for="CurrencyIsoCode">@T["Specific currency"]</label>
+
+        <div class="input-group">
+            <div class="input-group-append">
+                <select asp-for="CurrencyIsoCode"
+                        asp-items="@(new SelectList(Model.Currencies, "Text", "Value"))"></select>
+            </div>
+        </div>
+
+        <span class="hint">@T["Currency used for specific currency selection mode."]</span>*@
+    </fieldset>

--- a/Views/PricePartSettings.Edit.cshtml
+++ b/Views/PricePartSettings.Edit.cshtml
@@ -1,27 +1,45 @@
 @model PricePartSettingsViewModel
 
-    <fieldset class="form-group" asp-validation-class-for="PricePartSettings">
-        <label asp-for="CurrencySelectionMode">@T["Currency selection mode"]</label>
+<fieldset class="form-group" asp-validation-class-for="PricePartSettings">
+    <label asp-for="CurrencySelectionMode">@T["Currency selection mode"]</label>
 
-        <div class="input-group">
-            <div class="input-group-append">
-                <select asp-for="CurrencySelectionMode"
-                        asp-items="@(new SelectList(Model.CurrencySelectionModes, "Text", "Value"))"></select>
-            </div>
+    <div class="input-group">
+        <div class="input-group-append">
+            <select asp-for="CurrencySelectionMode"
+                    asp-items="@(new SelectList(Model.CurrencySelectionModes, "Text", "Value"))"></select>
         </div>
+    </div>
 
-        <span class="hint">@T["Specifies the currency configuration for this PricePart."]</span>
+    <span class="hint">@T["Specifies the currency configuration for this PricePart."]</span>
 
-        @* TODO: MP - Enable the block below when conditional display is done. *@
-            
-        @*<label asp-for="CurrencyIsoCode">@T["Specific currency"]</label>
-
+    <fieldset class="input-group" id="@Html.IdFor(m => m.SpecificCurrencyIsoCode)-Group">
         <div class="input-group">
             <div class="input-group-append">
-                <select asp-for="CurrencyIsoCode"
+                <select asp-for="SpecificCurrencyIsoCode"
                         asp-items="@(new SelectList(Model.Currencies, "Text", "Value"))"></select>
             </div>
         </div>
 
-        <span class="hint">@T["Currency used for specific currency selection mode."]</span>*@
+        <span class="hint">@T["Currency used for specific currency selection mode."]</span>
     </fieldset>
+</fieldset>
+
+<script at="Foot">
+$(function () {
+    $(document).ready(function () {
+        SpecificCurrencyGroupVisibility($('#@Html.IdFor(m => m.CurrencySelectionMode)'), $('#@Html.IdFor(m => m.SpecificCurrencyIsoCode)-Group'));
+    });
+
+    $('#@Html.IdFor(m => m.CurrencySelectionMode)').change(function () {
+        SpecificCurrencyGroupVisibility($(this), $('#@Html.IdFor(m => m.SpecificCurrencyIsoCode)-Group'));
+    });
+
+    function SpecificCurrencyGroupVisibility(element, group) {
+        if ('@Html.ValueFor(m => m.SingleSelectionModeEditor)' === element.val()) {
+            group.show();
+        } else {
+            group.hide();
+        }
+    }
+});
+</script>


### PR DESCRIPTION
Added a settings option on PricePart that makes it possible to configure/restrict what currencies are possible to select when entering data for a product. This way rules can be setup when the product type is designed and make the entered data more reliable.

**Possible options**:
1. All Currencies - The only option available today. If not configured when attaching the PricePart to a type this is the default.
2. Default Currency - Restricts the PricePart to the configured default currency. Useful for sites that only sells in a single market/region.
3. Specific Currency - The idea with this option is to make it possible to restrict the currency that can be selected for PricePart to a specific currency. Right now this option is disabled.

On a product type multiple PricePart objects can be attached with different configurations.

**Some examples**:

A site that only sells in one market/region can add a single PricePart to the product type and configure it to use the default currency.

A site that targets multiple markets/regions can add more than one PricePart when designing the product type. One PricePart with the default currency and additional PricePart objects configured for a specific currency. For this to work some kind of pricing strategy will need to be configured that selects the price in the correct currency.

![image](https://user-images.githubusercontent.com/49494169/74362311-c3ae4f00-4dc8-11ea-825b-5f3858a2cb50.png)
