### PR TITLE
Fix: TypePartSettings were not unique per instance

### DIFF
--- a/Drivers/PricePartDisplayDriver.cs
+++ b/Drivers/PricePartDisplayDriver.cs
@@ -7,6 +7,7 @@ using OrchardCore.Commerce.Models;
 using OrchardCore.Commerce.Settings;
 using OrchardCore.Commerce.ViewModels;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 
@@ -21,29 +22,30 @@ namespace OrchardCore.Commerce.Drivers
             _moneyService = moneyService;
         }
 
-        public override IDisplayResult Display(PricePart pricePart)
+        public override IDisplayResult Display(PricePart pricePart, BuildPartDisplayContext context)
         {
-            return Combine(
-                Initialize<PricePartViewModel>("PricePart", m => BuildViewModel(m, pricePart))
-                    .Location("Detail", "Content:25"),
-                Initialize<PricePartViewModel>("PricePart_Summary", m => BuildViewModel(m, pricePart))
-                    .Location("Summary", "Meta:10")
-            );
+            return Initialize<PricePartViewModel>(GetDisplayShapeType(context), m => BuildViewModel(m, pricePart))
+                .Location("Detail", "Content:25")
+                .Location("Summary", "Meta:10");
         }
 
-        public override IDisplayResult Edit(PricePart pricePart)
+        public override IDisplayResult Edit(PricePart pricePart, BuildPartEditorContext context)
         {
-            return Initialize<PricePartViewModel>("PricePart_Edit", m => BuildViewModel(m, pricePart));
+            var pricePartSettings = context.TypePartDefinition.GetSettings<PricePartSettings>();
+            pricePart.CurrencySelectionMode = pricePartSettings.CurrencySelectionMode;
+            pricePart.CurrencyIsoCode = pricePartSettings.SpecificCurrencyIsoCode;
+
+            return Initialize<PricePartViewModel>(GetEditorShapeType(context), m => BuildViewModel(m, pricePart));
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(PricePart model, IUpdateModel updater)
+        public override async Task<IDisplayResult> UpdateAsync(PricePart pricePart, IUpdateModel updater, UpdatePartEditorContext context)
         {
             var updateModel = new PricePartViewModel();
             await updater.TryUpdateModelAsync(updateModel, Prefix, t => t.PriceValue);
             await updater.TryUpdateModelAsync(updateModel, Prefix, t => t.PriceCurrency);
-            model.Price = _moneyService.Create(updateModel.PriceValue, updateModel.PriceCurrency);
+            pricePart.Price = _moneyService.Create(updateModel.PriceValue, updateModel.PriceCurrency);
 
-            return Edit(model);
+            return Edit(pricePart, context);
         }
 
         private Task BuildViewModel(PricePartViewModel model, PricePart part)

--- a/Handlers/PricePartHandler.cs
+++ b/Handlers/PricePartHandler.cs
@@ -1,30 +1,17 @@
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
-using OrchardCore.Commerce.Settings;
 using OrchardCore.ContentManagement.Handlers;
-using OrchardCore.ContentManagement.Metadata;
 
 namespace OrchardCore.Commerce.Handlers
 {
     public class PricePartHandler : ContentPartHandler<PricePart>
     {
         private readonly IMoneyService _moneyService;
-        private readonly IContentDefinitionManager _contentDefinitionManager;
 
-        public PricePartHandler(IMoneyService moneyService, IContentDefinitionManager contentDefinitionManager)
+        public PricePartHandler(IMoneyService moneyService)
         {
             _moneyService = moneyService;
-            _contentDefinitionManager = contentDefinitionManager;
-        }
-
-        public override Task InitializingAsync(InitializingContentContext context, PricePart part)
-        {
-            GetCurrencySelectionMode(part);
-
-            return base.InitializingAsync(context, part);
         }
 
         public override Task LoadingAsync(LoadContentContext context, PricePart part)
@@ -32,20 +19,6 @@ namespace OrchardCore.Commerce.Handlers
             part.Price = _moneyService.EnsureCurrency(part.Price);
 
             return base.LoadingAsync(context, part);
-        }
-
-        private void GetCurrencySelectionMode(PricePart part)
-        {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => x.PartDefinition.Name == nameof(PricePart));
-            var currencySelectionMode = contentTypePartDefinition.GetSettings<PricePartSettings>().CurrencySelectionMode;
-
-            part.CurrencySelectionMode = currencySelectionMode;
-
-            if (currencySelectionMode == CurrencySelectionModeEnum.SpecificCurrency)
-            {
-                part.CurrencyIsoCode = contentTypePartDefinition.GetSettings<PricePartSettings>().SpecificCurrencyIsoCode;
-            }
         }
     }
 }

--- a/Models/PricePart.cs
+++ b/Models/PricePart.cs
@@ -10,8 +10,5 @@ namespace OrchardCore.Commerce.Models
     public class PricePart : ContentPart
     {
         public Amount Price { get; set; } = new Amount(0, Currency.UnspecifiedCurrency);
-
-        public CurrencySelectionModeEnum CurrencySelectionMode { get; set; }
-        public string CurrencyIsoCode { get; set; }
     }
 }


### PR DESCRIPTION
Instance level PricePartSettings were not handled correctly. When multiple PricePart (named) instances were added to a type all got the same settings.
