### PR TITLE
Currency selector

### DIFF
--- a/Abstractions/ICurrencySelector.cs
+++ b/Abstractions/ICurrencySelector.cs
@@ -1,0 +1,15 @@
+using Money.Abstractions;
+
+namespace OrchardCore.Commerce.Abstractions
+{
+    /// <summary>
+    /// Implementations of this interface can alter the currency used for showing prices to the customer.
+    /// </summary>
+    public interface ICurrencySelector
+    {
+        /// <summary>
+        /// The current currency used for displaying prices to the customer.
+        /// </summary>
+        public ICurrency CurrentDisplayCurrency { get; }
+    }
+}

--- a/Abstractions/IMoneyService.cs
+++ b/Abstractions/IMoneyService.cs
@@ -38,6 +38,11 @@ namespace OrchardCore.Commerce.Abstractions
         ICurrency DefaultCurrency { get; }
 
         /// <summary>
+        /// The current currency used for displaying prices to the customer.
+        /// </summary>
+        ICurrency CurrentDisplayCurrency { get; }
+
+        /// <summary>
         /// Returns a new Amount where the currency has been verified to be resolved, or resolved.
         /// </summary>
         /// <param name="amount"></param>

--- a/CommerceConstants.cs
+++ b/CommerceConstants.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.Commerce
         {
             public const string Core = "OrchardCore.Commerce";
             public const string SessionCartStorage = "OrchardCore.Commerce.SessionCartStorage";
+            public const string CommerceSettingsCurrencySelector = "OrchardCore.Commerce.CommerceSettingsCurrencySelector";
         }
     }
 }

--- a/Drivers/PricePartDisplayDriver.cs
+++ b/Drivers/PricePartDisplayDriver.cs
@@ -61,6 +61,7 @@ namespace OrchardCore.Commerce.Drivers
             model.PriceValue = part.Price.Value;
             model.PriceCurrency = part.Price.Currency == Currency.UnspecifiedCurrency ? _moneyService.DefaultCurrency.CurrencyIsoCode : part.Price.Currency.CurrencyIsoCode;
             model.PricePart = part;
+            model.CurrentDisplayCurrency = _moneyService.CurrentDisplayCurrency;
 
             return Task.CompletedTask;
         }

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -31,3 +31,15 @@ using OrchardCore.Modules.Manifest;
         CommerceConstants.Features.Core
     }
 )]
+
+[assembly: Feature(
+    Id = CommerceConstants.Features.CommerceSettingsCurrencySelector,
+    Name = "Orchard Core Commerce Settings Currency Selector",
+    Category = "Commerce",
+    Description = "Currency selector that uses display currency configured in settings. Useful for Dev/Test scenarios.",
+    Dependencies = new[]
+    {
+        "OrchardCore.Contents",
+        CommerceConstants.Features.Core
+    }
+)]

--- a/Migrations/PriceMigrations.cs
+++ b/Migrations/PriceMigrations.cs
@@ -20,6 +20,7 @@ namespace OrchardCore.Commerce.Migrations
         {
             _contentDefinitionManager.AlterPartDefinition("PricePart", builder => builder
                 .Attachable()
+                .Reusable()
                 .WithDescription("Adds a simple price to a product."));
             return 1;
         }

--- a/Recipes/MultiCurrencyProduct.recipe.json
+++ b/Recipes/MultiCurrencyProduct.recipe.json
@@ -1,0 +1,135 @@
+{
+  "name": "MultiCurrencyProduct",
+  "displayName": "MultiCurrencyProduct",
+  "description": "Creates a Product content type with a Product Part and multiple Price Parts.",
+  "author": "The Orchard Team",
+  "website": "https://orchardproject.net",
+  "version": "2.0",
+  "issetuprecipe": false,
+  "categories": [ "commerce" ],
+  "tags": [ "product" ],
+  "steps": [
+    {
+      "name": "feature",
+      "disable": [],
+      "enable": [
+        "OrchardCore.Autoroute",
+        "OrchardCore.Html",
+        "OrchardCore.Title",
+        "OrchardCore.Commerce"
+      ]
+    },
+    {
+      "name": "ContentDefinition",
+      "ContentTypes": [
+        {
+          "Name": "MultiPriceProduct",
+          "DisplayName": "MultiPriceProduct",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Creatable": true,
+              "Listable": true,
+              "Draftable": true,
+              "Versionable": true,
+              "Securable": true
+            },
+            "FullTextAspectSettings": {}
+          },
+          "ContentTypePartDefinitionRecords": [
+          	{
+              "PartName": "TitlePart",
+              "Name": "TitlePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            },
+            {
+              "PartName": "AutoroutePart",
+              "Name": "AutoroutePart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "1"
+                }
+              }
+            },
+            {
+              "PartName": "HtmlBodyPart",
+              "Name": "HtmlBodyPart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "2",
+                  "Editor": "Wysiwyg"
+                },
+                "HtmlBodyPartSettings": {}
+              }
+            },
+            {
+              "PartName": "ProductPart",
+              "Name": "ProductPart",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "3"
+                }
+              }
+            },
+            {
+              "PartName": "PricePart",
+              "Name": "PriceUSD",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "DisplayName": "Price USD",
+                  "Description": "Adds a simple price to a product.",
+                  "Position": "4"
+                },
+                "PricePartSettings": {
+                  "CurrencySelectionMode": "DefaultCurrency"
+                }
+              }
+            },
+            {
+              "PartName": "PricePart",
+              "Name": "PriceSEK",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "DisplayName": "Price SEK",
+                  "Description": "Adds a simple price to a product.",
+                  "Position": "5"
+                },
+                "PricePartSettings": {
+                  "CurrencySelectionMode": "SpecificCurrency",
+                  "SpecificCurrencyIsoCode": "SEK"
+                }
+              }
+            },
+            {
+              "PartName": "PricePart",
+              "Name": "PriceNOK",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "DisplayName": "Price NOK",
+                  "Description": "Adds a simple price to a product.",
+                  "Position": "6"
+                },
+                "PricePartSettings": {
+                  "CurrencySelectionMode": "SpecificCurrency",
+                  "SpecificCurrencyIsoCode": "NOK"
+                }
+              }
+            },
+            {
+              "PartName": "MultiPriceProduct",
+              "Name": "MultiPriceProduct",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "7"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Services/MoneyService.cs
+++ b/Services/MoneyService.cs
@@ -16,14 +16,16 @@ namespace OrchardCore.Commerce.Services
     {
         private readonly IEnumerable<ICurrencyProvider> _currencyProviders;
         private readonly CommerceSettings _options;
-
+        private readonly ICurrencySelector _currencySelector;
 
         public MoneyService(
             IEnumerable<ICurrencyProvider> currencyProviders,
-            IOptions<CommerceSettings> options)
+            IOptions<CommerceSettings> options,
+            ICurrencySelector currencySelector)
         {
             _currencyProviders = currencyProviders ?? Array.Empty<ICurrencyProvider>();
             _options = options?.Value;
+            _currencySelector = currencySelector;
         }
 
         public IEnumerable<ICurrency> Currencies
@@ -38,6 +40,14 @@ namespace OrchardCore.Commerce.Services
                     ? Currency.USDollar
                     : GetCurrency(_options.DefaultCurrency)
                     ?? Currency.USDollar;
+            }
+        }
+
+        public ICurrency CurrentDisplayCurrency
+        {
+            get
+            {
+                return _currencySelector.CurrentDisplayCurrency ?? DefaultCurrency;
             }
         }
 

--- a/Services/NullCurrencySelector.cs
+++ b/Services/NullCurrencySelector.cs
@@ -1,0 +1,11 @@
+using System;
+using Money.Abstractions;
+using OrchardCore.Commerce.Abstractions;
+
+namespace OrchardCore.Commerce.Services
+{
+    public class NullCurrencySelector : ICurrencySelector
+    {
+        public ICurrency CurrentDisplayCurrency => null;
+    }
+}

--- a/Services/PriceProvider.cs
+++ b/Services/PriceProvider.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
 using OrchardCore.ContentManagement;
-using OrchardCore.ContentManagement.Metadata;
 
 namespace OrchardCore.Commerce.Services
 {
@@ -15,19 +14,13 @@ namespace OrchardCore.Commerce.Services
     {
         private readonly IProductService _productService;
         private readonly IMoneyService _moneyService;
-        private readonly IContentDefinitionManager _contentDefinitionManager;
-        private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
 
         public PriceProvider(
             IProductService productService,
-            IMoneyService moneyService,
-            IContentDefinitionManager contentDefinitionManager,
-            ITypeActivatorFactory<ContentPart> contentPartFactory)
+            IMoneyService moneyService)
         {
             _productService = productService;
             _moneyService = moneyService;
-            _contentDefinitionManager = contentDefinitionManager;
-            _contentPartFactory = contentPartFactory;
         }
 
         public int Order => 0;
@@ -41,47 +34,13 @@ namespace OrchardCore.Commerce.Services
             {
                 if (skuProducts.TryGetValue(item.ProductSku, out var product))
                 {
-                    ContentItem contentItem = product.ContentItem;
+                    var contentItem = product.ContentItem;
 
-                    // TODO: Swap the call below to extension method on ContentItem if approved in Orchard Core.
-                    //       Also Remove the temporary implementation of PartsOfType and dependencies on ContentDefinitionManager
-                    foreach (var pricePart in PartsOfType<PricePart>(contentItem))
+                    foreach (var pricePart in contentItem.OfType<PricePart>()
+                                 .Where(p => p.Price.Currency == _moneyService.CurrentDisplayCurrency))
                     {
-                        if (pricePart.Price.Currency == _moneyService.CurrentDisplayCurrency)
-                        {
-                            item.Prices.Add(new PrioritizedPrice(0, pricePart.Price));
-                        }
+                        item.Prices.Add(new PrioritizedPrice(0, pricePart.Price));
                     }
-
-                    //foreach (var pricePart in contentItem.OfType<PricePart>()
-                    //             .Where(p => p.Price.Currency == _moneyService.CurrentDisplayCurrency))
-                    //{
-                    //    item.Prices.Add(new PrioritizedPrice(0, pricePart.Price));
-                    //}
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets all content elements of a specific type.
-        /// </summary>
-        /// <typeparam name="TPart"></typeparam>
-        /// <param name="contentItem"></param>
-        /// <returns></returns>
-        public IEnumerable<TPart> PartsOfType<TPart>(ContentItem contentItem) where TPart : ContentPart
-        {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
-
-            foreach (var contentTypePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = contentTypePartDefinition.Name;
-                var partTypeName = contentTypePartDefinition.PartDefinition.Name;
-                var partActivator = _contentPartFactory.GetTypeActivator(partTypeName);
-                var part = contentItem.Get(partActivator.Type, partName) as TPart;
-
-                if (part != null)
-                {
-                    yield return part;
                 }
             }
         }

--- a/Services/PriceProvider.cs
+++ b/Services/PriceProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
 
 namespace OrchardCore.Commerce.Services
 {
@@ -13,10 +14,20 @@ namespace OrchardCore.Commerce.Services
     public class PriceProvider : IPriceProvider
     {
         private readonly IProductService _productService;
+        private readonly IMoneyService _moneyService;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
 
-        public PriceProvider(IProductService productService)
+        public PriceProvider(
+            IProductService productService,
+            IMoneyService moneyService,
+            IContentDefinitionManager contentDefinitionManager,
+            ITypeActivatorFactory<ContentPart> contentPartFactory)
         {
             _productService = productService;
+            _moneyService = moneyService;
+            _contentDefinitionManager = contentDefinitionManager;
+            _contentPartFactory = contentPartFactory;
         }
 
         public int Order => 0;
@@ -30,11 +41,47 @@ namespace OrchardCore.Commerce.Services
             {
                 if (skuProducts.TryGetValue(item.ProductSku, out var product))
                 {
-                    var pricePart = product.ContentItem.As<PricePart>();
-                    if (pricePart != null)
+                    ContentItem contentItem = product.ContentItem;
+
+                    // TODO: Swap the call below to extension method on ContentItem if approved in Orchard Core.
+                    //       Also Remove the temporary implementation of PartsOfType and dependencies on ContentDefinitionManager
+                    foreach (var pricePart in PartsOfType<PricePart>(contentItem))
                     {
-                        item.Prices.Add(new PrioritizedPrice(0, pricePart.Price));
+                        if (pricePart.Price.Currency == _moneyService.CurrentDisplayCurrency)
+                        {
+                            item.Prices.Add(new PrioritizedPrice(0, pricePart.Price));
+                        }
                     }
+
+                    //foreach (var pricePart in contentItem.OfType<PricePart>()
+                    //             .Where(p => p.Price.Currency == _moneyService.CurrentDisplayCurrency))
+                    //{
+                    //    item.Prices.Add(new PrioritizedPrice(0, pricePart.Price));
+                    //}
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets all content elements of a specific type.
+        /// </summary>
+        /// <typeparam name="TPart"></typeparam>
+        /// <param name="contentItem"></param>
+        /// <returns></returns>
+        public IEnumerable<TPart> PartsOfType<TPart>(ContentItem contentItem) where TPart : ContentPart
+        {
+            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+            foreach (var contentTypePartDefinition in contentTypeDefinition.Parts)
+            {
+                var partName = contentTypePartDefinition.Name;
+                var partTypeName = contentTypePartDefinition.PartDefinition.Name;
+                var partActivator = _contentPartFactory.GetTypeActivator(partTypeName);
+                var part = contentItem.Get(partActivator.Type, partName) as TPart;
+
+                if (part != null)
+                {
+                    yield return part;
                 }
             }
         }

--- a/Settings/CommerceSettings.cs
+++ b/Settings/CommerceSettings.cs
@@ -9,5 +9,7 @@ namespace OrchardCore.Commerce.Settings
         /// The default currency ISO code
         /// </summary>
         public string DefaultCurrency { get; set; }
+
+        public string CurrentDisplayCurrency { get; set; }
     }
 }

--- a/Settings/CommerceSettingsConfiguration.cs
+++ b/Settings/CommerceSettingsConfiguration.cs
@@ -25,6 +25,7 @@ namespace OrchardCore.Commerce.Settings
                 .As<CommerceSettings>();
 
             options.DefaultCurrency = settings.DefaultCurrency;
+            options.CurrentDisplayCurrency = settings.CurrentDisplayCurrency;
         }
     }
 }

--- a/Settings/CommerceSettingsCurrencySelector.cs
+++ b/Settings/CommerceSettingsCurrencySelector.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Options;
+using Money;
+using Money.Abstractions;
+using OrchardCore.Commerce.Abstractions;
+
+namespace OrchardCore.Commerce.Settings
+{
+    public class CommerceSettingsCurrencySelector : ICurrencySelector
+    {
+        private readonly CommerceSettings _options;
+
+        public CommerceSettingsCurrencySelector(IOptions<CommerceSettings> options)
+        {
+            _options = options.Value;
+        }
+        public ICurrency CurrentDisplayCurrency => Currency.FromISOCode(_options.CurrentDisplayCurrency);
+    }
+}

--- a/Settings/CommerceSettingsDisplayDriver.cs
+++ b/Settings/CommerceSettingsDisplayDriver.cs
@@ -55,6 +55,7 @@ namespace OrchardCore.Commerce.Settings
                 Initialize<CommerceSettingsViewModel>("CommerceSettings_Edit", model =>
                 {
                     model.DefaultCurrency = section.DefaultCurrency ?? _moneyService.DefaultCurrency.CurrencyIsoCode;
+                    model.CurrentDisplayCurrency = section.CurrentDisplayCurrency ?? _moneyService.DefaultCurrency.CurrencyIsoCode;
                     model.Currencies = _moneyService.Currencies
                         .OrderBy(c => c.CurrencyIsoCode)
                         .Select(c => new SelectListItem(
@@ -82,6 +83,7 @@ namespace OrchardCore.Commerce.Settings
                 if (await context.Updater.TryUpdateModelAsync(model, Prefix))
                 {
                     section.DefaultCurrency = model.DefaultCurrency;
+                    section.CurrentDisplayCurrency = model.CurrentDisplayCurrency;
                 }
 
                 // Reload the tenant to apply the settings

--- a/Startup.cs
+++ b/Startup.cs
@@ -70,6 +70,11 @@ namespace OrchardCore.Commerce
             // Currency
             services.AddScoped<ICurrencyProvider, CurrencyProvider>();
             services.AddScoped<IMoneyService, MoneyService>();
+
+            // Currency Display Strategies (Enable one of the below implementations).
+            services.AddScoped<ICurrencySelector, NullCurrencySelector>();
+            //services.AddScoped<ICurrencySelector, CommerceSettingsCurrencySelector>();
+
             // Shopping cart
             services.AddScoped<IShoppingCartHelpers, ShoppingCartHelpers>();
             // Settings

--- a/Startup.cs
+++ b/Startup.cs
@@ -70,10 +70,8 @@ namespace OrchardCore.Commerce
             // Currency
             services.AddScoped<ICurrencyProvider, CurrencyProvider>();
             services.AddScoped<IMoneyService, MoneyService>();
-
-            // Currency Display Strategies (Enable one of the below implementations).
+            // No display currency selected. Fall back to default currency logic in MoneyService.
             services.AddScoped<ICurrencySelector, NullCurrencySelector>();
-            //services.AddScoped<ICurrencySelector, CommerceSettingsCurrencySelector>();
 
             // Shopping cart
             services.AddScoped<IShoppingCartHelpers, ShoppingCartHelpers>();
@@ -105,6 +103,15 @@ namespace OrchardCore.Commerce
                 pattern: "shoppingcart/{action}",
                 defaults: new { controller = "ShoppingCart", action = "Index" }
             );
+        }
+    }
+
+    [RequireFeatures(CommerceConstants.Features.CommerceSettingsCurrencySelector)]
+    public class CommerceSettingsCurrencySettingsStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<ICurrencySelector, CommerceSettingsCurrencySelector>();
         }
     }
 }

--- a/ViewModels/CommerceSettingsViewModel.cs
+++ b/ViewModels/CommerceSettingsViewModel.cs
@@ -9,6 +9,8 @@ namespace OrchardCore.Commerce.ViewModels
     public class CommerceSettingsViewModel
     {
         public string DefaultCurrency { get; set; }
+        public string CurrentDisplayCurrency { get; set; }
+
         public IEnumerable<SelectListItem> Currencies { get; set; }
 
         [BindNever]

--- a/ViewModels/PricePartViewModel.cs
+++ b/ViewModels/PricePartViewModel.cs
@@ -14,6 +14,8 @@ namespace OrchardCore.Commerce.ViewModels
 
         public IEnumerable<ICurrency> Currencies { get; set; }
 
+        public ICurrency CurrentDisplayCurrency { get; set; }
+
         [BindNever]
         public ContentItem ContentItem { get; set; }
 

--- a/Views/CommerceSettings.Edit.cshtml
+++ b/Views/CommerceSettings.Edit.cshtml
@@ -13,4 +13,18 @@
     </div>
 
     <span class="hint">@T["The default currency used by the system."]</span>
+
+    <br />
+
+    <label asp-for="CurrentDisplayCurrency">@T["Current display currency"]</label>
+
+    <div class="input-group">
+        <div class="input-group-append">
+            <select asp-for="CurrentDisplayCurrency"
+                    asp-items="@(new SelectList(Model.Currencies, "Text", "Value"))"></select>
+        </div>
+    </div>
+
+    <span class="hint">@T["The currently used currency for displaying prices to customers."]</span>
+
 </fieldset>

--- a/Views/PricePart.cshtml
+++ b/Views/PricePart.cshtml
@@ -1,3 +1,6 @@
 @model PricePartViewModel
 
+@if (Model.CurrentDisplayCurrency.CurrencyIsoCode == Model.PriceCurrency)
+{
 <div class="product-price">@Model.Price.ToString()</div>
+}


### PR DESCRIPTION
Implemented logic to be able to select the currency prices are shown in on the site. It builds on the configuration settings that were added to the PricePart.

**There are two implementations added**: 
1. NullCurrencySelector - Don't affect anything. DefaultCurrency returned from MoneyService will be displayed.
2. CommerceSettingsCurrencySelector - Will use currency configured in commerce settings. Can be different from the default site currency configured. Good for testing.

Update in Startup.cs which implementation will be used.

**Notes**:
- Changed PricePart to be reusable by default.
- Updated PriceProvider to work with multiple currencies on a product. The selected currency is used for showing prices in the shopping cart.
- Added a sample recipe for a product with multiple PriceParts.
