### PR TITLE
Currency serialization

### DIFF
--- a/MoneyDataType/AmountConverter.cs
+++ b/MoneyDataType/AmountConverter.cs
@@ -25,7 +25,6 @@ namespace Money
             string symbol = null;
             string iso = null;
             int? dec = null;
-            bool unknown = false;
 
             while (reader.Read())
             {
@@ -46,33 +45,27 @@ namespace Money
                     // Kept for backwards compatibility
                     case Name:
                         nativename = reader.GetString();
-                        unknown = true;
                         break;
 
                     case NativeName:
                         nativename = reader.GetString();
-                        unknown = true;
                         break;
                     case EnglishName:
                         englishname = reader.GetString();
-                        unknown = true;
                         break;
                     case Symbol:
                         symbol = reader.GetString();
-                        unknown = true;
                         break;
                     case Iso:
                         iso = reader.GetString();
-                        unknown = true;
                         break;
                     case Dec:
                         if (reader.TryGetInt32(out var i)) dec = i;
-                        unknown = true;
                         break;
                 }
             }
 
-            if (unknown)
+            if (!Currency.IsKnownCurrency(currency?.CurrencyIsoCode ?? ""))
                 currency = new Currency(nativename, englishname, symbol, iso, dec.GetValueOrDefault(2));
 
             if (currency is null)

--- a/MoneyDataType/KnownCurrencyTable.cs
+++ b/MoneyDataType/KnownCurrencyTable.cs
@@ -36,6 +36,7 @@ namespace Money
                     .ToDictionary(k => k.CurrencyIsoCode, e => e);
 
                 CurrencyTable.Add("BTC", new Currency("BitCoin", "BitCoin", "₿", "BTC", 8));
+                CurrencyTable.Add("---", new Currency("Unspecified", "Unspecified", "---", "---"));
             }
         }
 

--- a/MoneyDataType/LegacyAmountConverter.cs
+++ b/MoneyDataType/LegacyAmountConverter.cs
@@ -63,10 +63,8 @@ namespace Money.Serialization
                 }
             }
 
-            if (!Currency.IsKnownCurrency(currency.CurrencyIsoCode))
-            {
+            if (!Currency.IsKnownCurrency(currency?.CurrencyIsoCode ?? ""))
                 currency = new Currency(nativename, englishname, symbol, iso, dec.GetValueOrDefault(2));
-            }
 
             if (currency is null)
                 throw new InvalidOperationException("Invalid amount format. Must include a currency");


### PR DESCRIPTION
Made a small change to the serialization of PricePart data. Currently data for the unspecified currency is stored. 
```json
	"PricePart": {
		"Price": {
			"value": 999.0,
			"nativename": "Unspecified",
			"englishname": "Unspecified",
			"symbol": "---",
			"iso": "---",
			"currency": "SEK"
		}
	},
```
Added it to the currency table to make it known and serialize like this.
```json
	"PricePart": {
		"Price": {
			"value": 99.0,
			"currency": "SEK"
		}
	},
```
