### PR TITLE
Currency Test failing in countries with decimal comma (,)

### DIFF
--- a/OrchardCore.Commerce.Tests/CurrencyTests.cs
+++ b/OrchardCore.Commerce.Tests/CurrencyTests.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.Commerce.Tests
                 { CanadianDollar, 1234.56m, "$1,234.56" },
                 { SwissFranc, 1234.56m, "CHF 1’234.56" },
                 { ChineseYuan, 1234.56m, "¥1,234.56" },
-                { new Currency("My FOO", "My FOO", "f", "FOO"), 1234.56m, "(FOO) 1,234.56" }
+                { new Currency("My FOO", "My FOO", "f", "FOO"), 1234.56m, $"(FOO) {1234.56m.ToString("N")}" }
             };
 
         [Theory]


### PR DESCRIPTION
Custom currency without regional/culture configuration fails in countries with decimal comma (,).

Changed test to pass with current system settings. Don't think it will be common use case to add currencies not available in the system.

