### PR TITLE
Update to .NET 5

### DIFF
--- a/AddressDataType/AddressDataType.csproj
+++ b/AddressDataType/AddressDataType.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>InternationalAddress</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/MoneyDataType/MoneyDataType.csproj
+++ b/MoneyDataType/MoneyDataType.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Money</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
+++ b/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>OrchardCore.Tests</AssemblyName>
     <PackageId>OrchardCore.Tests</PackageId>
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.9.0-preview-20201123-03" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.0.0-rc2-15734" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.9.4" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.0.0-rc2-16143" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/OrchardCore.Commerce/OrchardCore.Commerce.csproj
+++ b/OrchardCore.Commerce/OrchardCore.Commerce.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc2-15734" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-rc2-15734" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc2-15734" />
-    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.0.0-rc2-15734" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="1.0.0-rc2-15734" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc2-16143" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.0.0-rc2-16143" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc2-16143" />
+    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.0.0-rc2-16143" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="1.0.0-rc2-16143" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SampleWebApp/SampleWebApp.csproj
+++ b/SampleWebApp/SampleWebApp.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>true</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.0.0-rc2-15734" />
+    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.0.0-rc2-16143" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Open a discussion to see if .NET Framework 5.0 should be used by default.

Update Target Framework to `5.0` and latest version of the preview packages.