### PR TITLE
Add init submodules step to 'Setting up your dev env' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Globalization should be taken into account at every step.
 ## Setting up your dev environment
 
 1. Clone this repository.
-2. Build and run the `SampleWebApp` project.
-3. From the admin, enable the module's only feature.
-4. (optional) Start using the features, by creating a new `Product` content type, and adding the product part to it.
+2. If not already done, initialize submodules by running `git submodule update --init --recursive`.
+3. Build and run the `SampleWebApp` project.
+4. From the admin, enable the module's only feature.
+5. (optional) Start using the features, by creating a new `Product` content type, and adding the product part to it.
 
 ## Demo video
 


### PR DESCRIPTION
Cloning this repository using command line doesn't automatically
initiliaze submodules. Running SampleWebApp without submodules
results in a compile error, "file not found
'tools/Lombiq.Analyzers/Build.props'". From README file, it was
not obvious that there were submodules to initialize.