### PR TITLE
SITE-24: Fix bug related to displaying line items inside orders without charges

### DIFF
--- a/src/Modules/OrchardCore.Commerce/Views/OrderPart.cshtml
+++ b/src/Modules/OrchardCore.Commerce/Views/OrderPart.cshtml
@@ -1,7 +1,7 @@
 @model OrderPartViewModel
 
 <section id="shopping-cart">
-    @if (Model.Charges?.Any() == true)
+    @if (Model.LineItems?.Any() == true)
     {
         <div class="container">
             <table class="table">

--- a/src/Modules/OrchardCore.Commerce/Views/OrderPart_Edit.cshtml
+++ b/src/Modules/OrchardCore.Commerce/Views/OrderPart_Edit.cshtml
@@ -5,7 +5,7 @@
         <label>@T["Ordered Items"]</label>
     </div>
 
-    @if (Model.Charges?.Any() == true)
+    @if (Model.LineItems?.Any() == true)
     {
         <div class="container">
             <div class="d-none d-sm-flex row border-bottom mt-3 pb-2 font-weight-bold">
@@ -63,7 +63,7 @@
     <div class="panel-heading">
         <label>@T["Charges"]</label>
     </div>
-    @if (Model.Charges != null && Model.Charges.Any())
+    @if (Model.Charges?.Any() == true)
     {
         @foreach (var charge in Model.Charges)
         {


### PR DESCRIPTION
SITE-24

Line items were not displayed when there were no charges. This can be annoying in some debug situtation. Now for displaying line items we check the line items, not the charges.