### PR TITLE
NEST-362: Upgrade to Orchard Core 1.5

### DIFF
--- a/docs/resources/libraries/README.md
+++ b/docs/resources/libraries/README.md
@@ -4,7 +4,7 @@ The below table lists the different .NET libraries used in Orchard Core Commerce
 
 | Library | Usage | Version | License |
 |--- | --- | --- | --- |
-| [Orchard Core](https://github.com/OrchardCMS/OrchardCore) | Modular and multi-tenant application framework. | 1.4.0 |[BSD-3-Clause](https://github.com/OrchardCMS/OrchardCore/blob/main/LICENSE) |
+| [Orchard Core](https://github.com/OrchardCMS/OrchardCore) | Modular and multi-tenant application framework. | 1.5.0 |[BSD-3-Clause](https://github.com/OrchardCMS/OrchardCore/blob/main/LICENSE) |
 | [Shouldly](https://github.com/shouldly/shouldly) | Should testing for .NET | 4.1.0 |[BSD license](https://github.com/shouldly/shouldly/blob/master/LICENSE.txt) |
 | [Stripe.net](https://github.com/shouldly/shouldly) | Portable class library for stripe.com | 40.4.0 |[Apache 2.0](https://github.com/shouldly/shouldly/blob/master/LICENSE.txt) |
 

--- a/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
+++ b/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Indexing.Abstractions" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.4.0" />
+    <PackageReference Include="OrchardCore.Indexing.Abstractions" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
+++ b/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
@@ -42,7 +42,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="4.7.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.Promotion/OrchardCore.Commerce.Promotion.csproj
+++ b/src/Modules/OrchardCore.Commerce.Promotion/OrchardCore.Commerce.Promotion.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.4.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/OrchardCore.Commerce.Tax/OrchardCore.Commerce.Tax.csproj
+++ b/src/Modules/OrchardCore.Commerce.Tax/OrchardCore.Commerce.Tax.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.4.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/OrchardCore.Commerce.Tax/OrchardCore.Commerce.Tax.csproj
+++ b/src/Modules/OrchardCore.Commerce.Tax/OrchardCore.Commerce.Tax.csproj
@@ -42,7 +42,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="4.7.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce/Drivers/PriceVariantsPartDisplayDriver.cs
+++ b/src/Modules/OrchardCore.Commerce/Drivers/PriceVariantsPartDisplayDriver.cs
@@ -1,4 +1,3 @@
-using GraphQL;
 using Microsoft.Extensions.Options;
 using OrchardCore.Commerce.Abstractions;
 using OrchardCore.Commerce.Models;

--- a/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
+++ b/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Libraries\OrchardCore.Commerce.AddressDataType\OrchardCore.Commerce.AddressDataType.csproj" />
+    <ProjectReference Include="..\OrchardCore.Commerce.Promotion\OrchardCore.Commerce.Promotion.csproj" />
     <ProjectReference Include="..\OrchardCore.Commerce.Tax\OrchardCore.Commerce.Tax.csproj" />
   </ItemGroup>
 

--- a/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
+++ b/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -27,21 +27,19 @@
 
   <ItemGroup>
     <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.0.0-alpha.occ-15.3" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Html" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Title" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Templates" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="1.4.0" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Html" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Title" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="1.5.0" />
     <PackageReference Include="Stripe.net" Version="40.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Libraries\OrchardCore.Commerce.AddressDataType\OrchardCore.Commerce.AddressDataType.csproj" />
-    <ProjectReference Include="..\OrchardCore.Commerce.Promotion\OrchardCore.Commerce.Promotion.csproj" />
     <ProjectReference Include="..\OrchardCore.Commerce.Tax\OrchardCore.Commerce.Tax.csproj" />
   </ItemGroup>
 

--- a/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
+++ b/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="OrchardCore.Module.Targets" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Navigation.Core" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Title" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Templates" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="1.5.0" />
     <PackageReference Include="Stripe.net" Version="40.4.0" />
   </ItemGroup>

--- a/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
+++ b/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="4.7.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
+++ b/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.0.0-alpha.occ-15.3" />
     <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="4.0.1" />
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.4.0" />
-    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.4.0" />
+    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.5.0" />
+    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
+++ b/test/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.4.0" />
+    <PackageReference Include="OrchardCore.ContentFields" Version="1.5.0" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
NEST-362

Continuation of [skrypt/1.5](https://github.com/OrchardCMS/OrchardCore.Commerce/tree/skrypt/1.5), now that Lombiq submodules are updated to OC 1.5