### PR TITLE
OCC-152: Publish to NuGet step fails in publish workflow

### DIFF
--- a/.github/workflows/publish-cloudsmith.yml
+++ b/.github/workflows/publish-cloudsmith.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   call-publish-workflow:
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OCC-152
     with:
       source: https://nuget.cloudsmith.io/orchardcore/commerce/v3/index.json
       publish-version: "USE_GITHUB_RUN_NUMBER"

--- a/.github/workflows/publish-cloudsmith.yml
+++ b/.github/workflows/publish-cloudsmith.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   call-publish-workflow:
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OCC-152
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
     with:
       source: https://nuget.cloudsmith.io/orchardcore/commerce/v3/index.json
       publish-version: "USE_GITHUB_RUN_NUMBER"

--- a/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
+++ b/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>true</CopyRefAssembliesToPublishDirectory>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <!-- Currently we don't have any ps1/psm1/psd1 files in the repo, so this is commented out. Add the ProjectReference

--- a/test/OrchardCore.Commerce.Tests.UI/OrchardCore.Commerce.Tests.UI.csproj
+++ b/test/OrchardCore.Commerce.Tests.UI/OrchardCore.Commerce.Tests.UI.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
+++ b/test/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>OrchardCore.Tests</AssemblyName>
     <PackageId>OrchardCore.Tests</PackageId>
     <OutputType>Library</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
OCC-152

- ✔️ `dotnet pack` no longer crashes.
- ✔️ [Now the preview packages are correctly versioned (1.0.1) on CloudSmith.](https://cloudsmith.io/~orchardcore/repos/commerce/packages/)

Fixes #286