### PR TITLE
NEST-463: Fixing 'ContentOrchardHelperExtensions.GetItemDisplayUrlAsync(IOrchardHelper, ContentItem)' is obsolete: 'Use GetItemDisplayUrl instead as this method does not need to be async.'

### DIFF
--- a/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
+++ b/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
@@ -44,7 +44,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="6.0.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="6.0.1-alpha.0.gov-15" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.Inventory/OrchardCore.Commerce.Inventory.csproj
+++ b/src/Modules/OrchardCore.Commerce.Inventory/OrchardCore.Commerce.Inventory.csproj
@@ -41,7 +41,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="6.0.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="6.0.1-alpha.0.gov-15" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce/Services/OrderLineItemService.cs
+++ b/src/Modules/OrchardCore.Commerce/Services/OrderLineItemService.cs
@@ -81,9 +81,9 @@ public class OrderLineItemService : IOrderLineItemService
             shipping,
             billing,
             orderPart?.ContentItem?.PublishedUtc ?? _clock.UtcNow,
-            VatNumber: orderPart.VatNumber.Text,
+            VatNumber: orderPart?.VatNumber.Text,
             Stored: true,
-            IsCorporation: orderPart.IsCorporation.Value);
+            IsCorporation: orderPart?.IsCorporation.Value ?? false);
         var changed = false;
 
         if (_taxProviders.Any() &&

--- a/src/Modules/OrchardCore.Commerce/Views/ShoppingCartCell_Product.cshtml
+++ b/src/Modules/OrchardCore.Commerce/Views/ShoppingCartCell_Product.cshtml
@@ -7,7 +7,7 @@
     var attributes = (IList<(IProductAttributeValue Value, string Type, int Index)>)Model.ProductAttributes;
 }
 
-<a href="@await Orchard.GetItemDisplayUrlAsync(line.Product.ContentItem)" class="link-primary">@line.ProductName</a>
+<a href="@Orchard.GetItemDisplayUrl(line.Product.ContentItem)" class="link-primary">@line.ProductName</a>
 @if (line.Attributes?.Any() == true)
 {
     <ul class="cart-product-attributes list-inline">

--- a/test/OrchardCore.Commerce.Tests.UI.Shortcuts/OrchardCore.Commerce.Tests.UI.Shortcuts.csproj
+++ b/test/OrchardCore.Commerce.Tests.UI.Shortcuts/OrchardCore.Commerce.Tests.UI.Shortcuts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -29,7 +29,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="6.0.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="6.0.1-alpha.0.gov-15" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NEST-463