### PR TITLE
Fix ReadTheDocs build error

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation with MkDocs
 mkdocs:
   configuration: mkdocs.yml
@@ -13,6 +18,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Error on build:
`Invalid configuration option "build.os": build not found`