### PR TITLE
OCC-218: Update NuGet packages and migrate to centralized package management

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -3,6 +3,7 @@ Contributors.md$
 docs/releases
 docs/requirements\.txt$
 mkdocs\.yml$
+Directory.Packages.props$
 src/Libraries/OrchardCore\.Commerce\.MoneyDataType/Currency\.extra\.cs$
 src/Modules/OrchardCore\.Commerce\.Payment/Constants/CurrencyCollectionConstants\.cs$
 src/Modules/OrchardCore\.Commerce\.Payment\.Stripe/Extensions/PaymentExtensions\.cs$

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>-->
 
   <ItemGroup>
-    <PackageReference Condition="!Exists($(LombiqAnalyzersPath))" Include="Lombiq.Analyzers.OrchardCore" Version="4.0.0">
+    <PackageReference Condition="!Exists($(LombiqAnalyzersPath))" Include="Lombiq.Analyzers.OrchardCore">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.6.tdeal-16" />
     <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
     <PackageVersion Include="Lombiq.Tests" Version="2.2.5" />
-    <PackageVersion Include="Lombiq.Tests.UI" Version="8.2.1-alpha.21.osoe-817" />
-    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
-    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.21.osoe-817" />
+    <PackageVersion Include="Lombiq.Tests.UI" Version="9.0.0-alpha.1.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="9.0.0-alpha.1.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="9.0.0-alpha.1.occ-218" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,41 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Lombiq.Analyzers.OrchardCore" Version="4.0.0" />
+    <PackageVersion Include="Lombiq.Tests" Version="2.2.3" />
+    <PackageVersion Include="Lombiq.Tests.UI" Version="8.2.1-alpha.21.osoe-817" />
+    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
+    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.21.osoe-817" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.ContentFields" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.ContentManagement" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.ContentManagement.Abstractions" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.ContentTypes" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.ContentTypes.Abstractions" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Html" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Indexing.Abstractions" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Localization" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Logging.NLog" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Module.Targets" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Navigation.Core" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Templates" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Title" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Workflows.Abstractions" Version="1.7.0" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="Stripe.net" Version="41.27.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
+    <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists($(LombiqNodeJsExtensionsPath))">
+    <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="9.1.0" />
     <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="2.1.0" />
     <PackageVersion Include="Lombiq.Tests" Version="3.0.0" />
-    <PackageVersion Include="Lombiq.Tests.UI" Version="9.0.0-alpha.2.occ-218" />
-    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="9.0.0-alpha.2.occ-218" />
-    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="9.0.0-alpha.2.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI" Version="9.0.1-alpha.2.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="9.0.1-alpha.2.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="9.0.1-alpha.2.occ-218" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,9 @@
 
   <ItemGroup>
     <PackageVersion Include="Lombiq.Analyzers.OrchardCore" Version="4.0.0" />
-    <PackageVersion Include="Lombiq.Tests" Version="2.2.3" />
+    <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.6.tdeal-16" />
+    <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
+    <PackageVersion Include="Lombiq.Tests" Version="2.2.5" />
     <PackageVersion Include="Lombiq.Tests.UI" Version="8.2.1-alpha.21.osoe-817" />
     <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
     <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.21.osoe-817" />
@@ -32,11 +34,5 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.2" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
-  </ItemGroup>
-  <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
-  </ItemGroup>
-  <ItemGroup Condition="!Exists($(LombiqNodeJsExtensionsPath))">
-    <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="9.1.0" />
     <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="2.1.0" />
     <PackageVersion Include="Lombiq.Tests" Version="3.0.0" />
-    <PackageVersion Include="Lombiq.Tests.UI" Version="9.0.0-alpha.1.occ-218" />
-    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="9.0.0-alpha.1.occ-218" />
-    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="9.0.0-alpha.1.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI" Version="9.0.0-alpha.2.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="9.0.0-alpha.2.occ-218" />
+    <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="9.0.0-alpha.2.occ-218" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,30 +5,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Lombiq.Analyzers.OrchardCore" Version="4.0.0" />
-    <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.6.tdeal-16" />
-    <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
-    <PackageVersion Include="Lombiq.Tests" Version="2.2.5" />
+    <PackageVersion Include="Lombiq.Analyzers.OrchardCore" Version="5.0.0" />
+    <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="9.1.0" />
+    <PackageVersion Include="Lombiq.NodeJs.Extensions" Version="2.1.0" />
+    <PackageVersion Include="Lombiq.Tests" Version="3.0.0" />
     <PackageVersion Include="Lombiq.Tests.UI" Version="9.0.0-alpha.1.occ-218" />
     <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="9.0.0-alpha.1.occ-218" />
     <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="9.0.0-alpha.1.occ-218" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.ContentFields" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.ContentManagement" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.ContentManagement.Abstractions" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.ContentTypes" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.ContentTypes.Abstractions" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Html" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Indexing.Abstractions" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Localization" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Logging.NLog" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Module.Targets" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Navigation.Core" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Templates" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Title" Version="1.7.2" />
-    <PackageVersion Include="OrchardCore.Workflows.Abstractions" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.ContentFields" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.ContentManagement" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.ContentManagement.Abstractions" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.ContentTypes" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.ContentTypes.Abstractions" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Html" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Indexing.Abstractions" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Localization" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Logging.NLog" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Module.Targets" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Navigation.Core" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Templates" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Title" Version="1.8.2" />
+    <PackageVersion Include="OrchardCore.Workflows.Abstractions" Version="1.8.2" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="Stripe.net" Version="43.15.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,34 +3,35 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageVersion Include="Lombiq.Analyzers.OrchardCore" Version="4.0.0" />
     <PackageVersion Include="Lombiq.Tests" Version="2.2.3" />
     <PackageVersion Include="Lombiq.Tests.UI" Version="8.2.1-alpha.21.osoe-817" />
     <PackageVersion Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
     <PackageVersion Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.21.osoe-817" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.ContentFields" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.ContentManagement" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.ContentManagement.Abstractions" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.ContentTypes" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.ContentTypes.Abstractions" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Html" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Indexing.Abstractions" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Localization" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Logging.NLog" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Module.Targets" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Navigation.Core" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Templates" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Title" Version="1.7.0" />
-    <PackageVersion Include="OrchardCore.Workflows.Abstractions" Version="1.7.0" />
+    <PackageVersion Include="OrchardCore.Application.Cms.Targets" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.ContentFields" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.ContentManagement" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.ContentManagement.Abstractions" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.ContentTypes" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.ContentTypes.Abstractions" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Html" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Indexing.Abstractions" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Localization" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Logging.NLog" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Module.Targets" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Navigation.Core" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Templates" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Title" Version="1.7.2" />
+    <PackageVersion Include="OrchardCore.Workflows.Abstractions" Version="1.7.2" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="Stripe.net" Version="41.27.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="Stripe.net" Version="43.15.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
+    <PackageVersion Include="xunit" Version="2.7.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
     <PackageVersion Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Based on https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping#enable-by-manually-editing-nugetconfig. -->
 <configuration>
-	<packageSources>
-		<add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-	</packageSources>
+    <!-- Define the package sources, `clear` ensures no additional sources are inherited from another config file. -->
+    <packageSources>
+        <clear />
+        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+        <add key="orchardcore-commerce" value="https://nuget.cloudsmith.io/orchardcore/commerce/v3/index.json" />
+    </packageSources>
+
+    <!-- Define mappings by adding package patterns beneath the target source. -->
+    <!-- OrchardCore.Commerce* packages will be restored from orchardcore-commerce, everything else from nuget.org. -->
+    <packageSourceMapping>
+        <packageSource key="NuGet">
+            <package pattern="*" />
+        </packageSource>
+        <packageSource key="orchardcore-commerce">
+            <package pattern="OrchardCore.Commerce*" />
+        </packageSource>
+    </packageSourceMapping>
 </configuration>

--- a/OrchardCore.Commerce.sln
+++ b/OrchardCore.Commerce.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Nuget.config = Nuget.config
 		Readme.md = Readme.md
 		Reset-Local.ps1 = Reset-Local.ps1
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B2D057AA-E3F7-404D-A713-C3C59F9DE562}"

--- a/src/Libraries/OrchardCore.Commerce.Abstractions/OrchardCore.Commerce.Abstractions.csproj
+++ b/src/Libraries/OrchardCore.Commerce.Abstractions/OrchardCore.Commerce.Abstractions.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="License.md" Pack="true" PackagePath=""/>
-    <None Include="Readme.md"/>
+    <None Include="License.md" Pack="true" PackagePath="" />
+    <None Include="Readme.md" />
     <None Include="OrchardCoreIcon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
@@ -29,14 +29,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.ContentFields" />
   </ItemGroup>
 
   <ItemGroup Condition="Exists($(LombiqHelpfulLibrariesPath))">
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)\Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" />
   </ItemGroup>
 
 </Project>

--- a/src/Libraries/OrchardCore.Commerce.MoneyDataType/OrchardCore.Commerce.MoneyDataType.csproj
+++ b/src/Libraries/OrchardCore.Commerce.MoneyDataType/OrchardCore.Commerce.MoneyDataType.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
+++ b/src/Modules/OrchardCore.Commerce.ContentFields/OrchardCore.Commerce.ContentFields.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Indexing.Abstractions" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Templates" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.Indexing.Abstractions" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.Templates" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,7 +41,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)\Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" />
   </ItemGroup>
 
   <ItemGroup Condition="Exists($(LombiqNodeJsExtensionsPath))">
@@ -52,7 +52,7 @@
     <Import Project="$(LombiqNodeJsExtensionsPath)\Lombiq.NodeJs.Extensions.targets" />
   </ImportGroup>
   <ItemGroup Condition="!Exists($(LombiqNodeJsExtensionsPath))">
-    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
+    <PackageReference Include="Lombiq.NodeJs.Extensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.Inventory/OrchardCore.Commerce.Inventory.csproj
+++ b/src/Modules/OrchardCore.Commerce.Inventory/OrchardCore.Commerce.Inventory.csproj
@@ -28,16 +28,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.ContentFields" />
+    <PackageReference Include="OrchardCore.ContentManagement" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
   </ItemGroup>
 
   <ItemGroup Condition="Exists($(LombiqHelpfulLibrariesPath))">
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)\Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.Payment.Stripe/OrchardCore.Commerce.Payment.Stripe.csproj
+++ b/src/Modules/OrchardCore.Commerce.Payment.Stripe/OrchardCore.Commerce.Payment.Stripe.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0"/>
-    <PackageReference Include="Stripe.net" Version="41.27.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="Stripe.net" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,7 +45,7 @@
     <Import Project="$(LombiqNodeJsExtensionsPath)\Lombiq.NodeJs.Extensions.targets" />
   </ImportGroup>
   <ItemGroup Condition="!Exists($(LombiqNodeJsExtensionsPath))">
-    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
+    <PackageReference Include="Lombiq.NodeJs.Extensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.Payment/OrchardCore.Commerce.Payment.csproj
+++ b/src/Modules/OrchardCore.Commerce.Payment/OrchardCore.Commerce.Payment.csproj
@@ -34,16 +34,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.ContentFields" />
+    <PackageReference Include="OrchardCore.ContentManagement" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
   </ItemGroup>
 
   <ItemGroup Condition="Exists($(LombiqHelpfulLibrariesPath))">
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)\Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" />
   </ItemGroup>
 
   <ItemGroup Condition="Exists($(LombiqNodeJsExtensionsPath))">
@@ -54,7 +54,7 @@
     <Import Project="$(LombiqNodeJsExtensionsPath)\Lombiq.NodeJs.Extensions.targets" />
   </ImportGroup>
   <ItemGroup Condition="!Exists($(LombiqNodeJsExtensionsPath))">
-    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
+    <PackageReference Include="Lombiq.NodeJs.Extensions" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/OrchardCore.Commerce.Promotion/OrchardCore.Commerce.Promotion.csproj
+++ b/src/Modules/OrchardCore.Commerce.Promotion/OrchardCore.Commerce.Promotion.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.ContentFields" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/OrchardCore.Commerce.Tax/OrchardCore.Commerce.Tax.csproj
+++ b/src/Modules/OrchardCore.Commerce.Tax/OrchardCore.Commerce.Tax.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.ContentFields" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
+++ b/src/Modules/OrchardCore.Commerce/OrchardCore.Commerce.csproj
@@ -27,16 +27,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentTypes" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Html" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Localization" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Navigation.Core" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Title" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Workflows.Abstractions" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.ContentFields" />
+    <PackageReference Include="OrchardCore.ContentManagement" />
+    <PackageReference Include="OrchardCore.ContentTypes" />
+    <PackageReference Include="OrchardCore.ContentTypes.Abstractions" />
+    <PackageReference Include="OrchardCore.Html" />
+    <PackageReference Include="OrchardCore.Localization" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.Navigation.Core" />
+    <PackageReference Include="OrchardCore.Title" />
+    <PackageReference Include="OrchardCore.Workflows.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
@@ -60,7 +60,7 @@
     <Import Project="$(LombiqNodeJsExtensionsPath)\Lombiq.NodeJs.Extensions.targets" />
   </ImportGroup>
   <ItemGroup Condition="!Exists($(LombiqNodeJsExtensionsPath))">
-    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.2" />
+    <PackageReference Include="Lombiq.NodeJs.Extensions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
+++ b/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
@@ -13,10 +13,10 @@
   </ItemGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
-    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.21.osoe-817" />
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.Logging.NLog" Version="1.7.0" />
+    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" />
+    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" />
+    <PackageReference Include="OrchardCore.Application.Cms.Targets" />
+    <PackageReference Include="OrchardCore.Logging.NLog" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
+++ b/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
@@ -13,8 +13,8 @@
   </ItemGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.14.osoe-767" />
-    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.14.osoe-767" />
+    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
+    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="8.2.1-alpha.21.osoe-817" />
     <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="1.7.0" />
     <PackageReference Include="OrchardCore.Logging.NLog" Version="1.7.0" />
   </ItemGroup>

--- a/test/OrchardCore.Commerce.Tests.UI.Shortcuts/OrchardCore.Commerce.Tests.UI.Shortcuts.csproj
+++ b/test/OrchardCore.Commerce.Tests.UI.Shortcuts/OrchardCore.Commerce.Tests.UI.Shortcuts.csproj
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.7.0" />
-    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" Version="1.7.0" />
+    <PackageReference Include="OrchardCore.Module.Targets" />
+    <PackageReference Include="OrchardCore.ContentManagement" />
+    <PackageReference Include="OrchardCore.ContentManagement.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,7 +44,7 @@
     <ProjectReference Include="$(LombiqHelpfulLibrariesPath)\Lombiq.HelpfulLibraries.OrchardCore/Lombiq.HelpfulLibraries.OrchardCore.csproj" />
   </ItemGroup>
   <ItemGroup Condition="!Exists($(LombiqHelpfulLibrariesPath))">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="8.1.1-alpha.5.tdeal-16" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" />
   </ItemGroup>
 
 </Project>

--- a/test/OrchardCore.Commerce.Tests.UI/OrchardCore.Commerce.Tests.UI.csproj
+++ b/test/OrchardCore.Commerce.Tests.UI/OrchardCore.Commerce.Tests.UI.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Lombiq.Tests.UI" Version="8.2.1-alpha.21.osoe-817" />
-      <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PackageReference Include="Lombiq.Tests.UI" />
+      <PackageReference Include="Lombiq.Tests.UI.AppExtensions" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="xunit.runner.visualstudio">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/OrchardCore.Commerce.Tests.UI/OrchardCore.Commerce.Tests.UI.csproj
+++ b/test/OrchardCore.Commerce.Tests.UI/OrchardCore.Commerce.Tests.UI.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Lombiq.Tests.UI" Version="8.2.1-alpha.14.osoe-767" />
-      <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.14.osoe-767" />
+      <PackageReference Include="Lombiq.Tests.UI" Version="8.2.1-alpha.21.osoe-817" />
+      <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="8.2.1-alpha.21.osoe-817" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
         <PrivateAssets>all</PrivateAssets>

--- a/test/OrchardCore.Commerce.Tests.UI/Tests/BasicTests/SecurityScanningTests.cs
+++ b/test/OrchardCore.Commerce.Tests.UI/Tests/BasicTests/SecurityScanningTests.cs
@@ -42,7 +42,7 @@ public class SecurityScanningTests : UITestBase
                 }),
             changeConfiguration: configuration => configuration.AssertAppLogsAsync = async webApplicationInstance =>
             {
-                var logsWithoutUnwantedExpectionMessages = (await webApplicationInstance.GetLogOutputAsync())
+                var logsWithoutUnwantedExceptionMessages = (await webApplicationInstance.GetLogOutputAsync())
                     .SplitByNewLines()
                     .Where(message =>
                         !message.ContainsOrdinalIgnoreCase("System.IO.DirectoryNotFoundException: Could not find a part of the path") &&
@@ -50,7 +50,7 @@ public class SecurityScanningTests : UITestBase
                             "System.IO.IOException: The filename, directory name, or volume label syntax is incorrect") &&
                         !message.ContainsOrdinalIgnoreCase("System.InvalidOperationException: This action intentionally causes an exception!"));
 
-                logsWithoutUnwantedExpectionMessages.ShouldNotContain(item => item.Contains("|ERROR|"));
+                logsWithoutUnwantedExceptionMessages.ShouldNotContain(item => item.Contains("|ERROR|"));
             });
 
     private static void FalsePositive(

--- a/test/OrchardCore.Commerce.Tests.UI/Tests/BasicTests/SecurityScanningTests.cs
+++ b/test/OrchardCore.Commerce.Tests.UI/Tests/BasicTests/SecurityScanningTests.cs
@@ -20,6 +20,10 @@ public class SecurityScanningTests : UITestBase
                 configuration =>
                 {
                     configuration.DisableActiveScanRule(
+                        6,
+                        "Path Traversal (all paths are virtual so it's not a real concern, also creates too many errors)");
+
+                    configuration.DisableActiveScanRule(
                         40024,
                         "SQL Injection - SQLite (everything goes through YesSql so these are false positive)");
 

--- a/test/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
+++ b/test/OrchardCore.Commerce.Tests/OrchardCore.Commerce.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lombiq.Tests" Version="2.2.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="OrchardCore.ContentFields" Version="1.7.0" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Lombiq.Tests" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="OrchardCore.ContentFields" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
[OCC-218](https://lombiq.atlassian.net/browse/OCC-218)
Since this project will never have submodules it makes sense to use _Directory.Packages.props_ and get rid of the tedium of upgrading each csproj individually. Going forward we'll only have more project files so it's best to do it now than later.
Fixes #404