### PR TITLE
Docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-mkdocs>=1.3.1
-mkdocs-material>=8.4.2
-mkdocs-git-authors-plugin>=0.6.4
-mkdocs-git-revision-date-localized-plugin>=1.1.0
-pymdown-extensions>=9.5
+mkdocs>=1.6.0
+mkdocs-material>=9.5.20
+mkdocs-git-authors-plugin>=0.8.0
+mkdocs-git-revision-date-localized-plugin>=1.2.5
+pymdown-extensions>=10.8.1
 mkdocs-exclude>=1.0.2
 mdx_truly_sane_lists>=1.2


### PR DESCRIPTION
Update docs requirements.

I updated the settings on Crowdin to not display this banner: 
![image](https://github.com/OrchardCMS/OrchardCore.Commerce/assets/703248/6917822e-4b9a-4dbe-9df1-fcd94c8377d0)

On merge, it will trigger a new build and should update the docs taking this setting into account.