### PR TITLE
ADHOC-475: Fixing that tenant URL prefix is not applied in the product list filter form

### DIFF
--- a/src/Modules/OrchardCore.Commerce/Views/ProductListPart.Filters.cshtml
+++ b/src/Modules/OrchardCore.Commerce/Views/ProductListPart.Filters.cshtml
@@ -16,7 +16,7 @@
 
 <h3>@T["Filter Products"]</h3>
 
-<form method="get" action="@Context.Request.Path">
+<form method="get" action="@Href("~" + Context.Request.Path)">
     @foreach (var filterId in Model.FilterIds)
     {
         var shapeType = "ProductList__Filter__" + filterId;


### PR DESCRIPTION
[ADHOC-475](https://lombiq.atlassian.net/browse/ADHOC-475)
There's no related issue; it was connected to another development task of mine where I implemented something similar. I encountered this bug and realized it will be an issue here, too.