### PR TITLE
Update Orchard Core 2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!-- The Orchard Core version should always be x.y.0 of the latest minor version for maximum compatibility when
          distributed as NuGet packages. On the other hand, the consuming projects (including OrchardCore.Commerce.Web)
          should use Orchard Core references for the latest patch version to pull all versions up in the final app. -->
-    <OrchardCoreVersion>1.8.0</OrchardCoreVersion>
+    <OrchardCoreVersion>2.0.0</OrchardCoreVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
+++ b/src/OrchardCore.Commerce.Web/OrchardCore.Commerce.Web.csproj
@@ -18,8 +18,8 @@
 
     <!-- The Orchard Core packages must override the version to target the latest patch version in this project. See the
          Directory.Packages.props file for more details. -->
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" VersionOverride="1.8.3" />
-    <PackageReference Include="OrchardCore.Logging.NLog" VersionOverride="1.8.3" />
+    <PackageReference Include="OrchardCore.Application.Cms.Targets" VersionOverride="2.0.0" />
+    <PackageReference Include="OrchardCore.Logging.NLog" VersionOverride="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@sarahelsaig This might need to bump all of the Lombiq packages to use `OC 2.0.0`, please let me know if you need help there or merge after updating Lombiq packages