### PR TITLE
Fix launch settings for VS Code

### DIFF
--- a/src/OrchardCore.Commerce.Web/Properties/launchSettings.json
+++ b/src/OrchardCore.Commerce.Web/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://*:5001;http://*:5000"
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }


### PR DESCRIPTION
Under Windows, from what I tested, it fails starting the browser with VS Code with the current settings. This fix that issue.