### PR TITLE
Only invoked CreatedFreeAsync event when a free (non-payment) order is created

### DIFF
--- a/src/Modules/OrchardCore.Commerce.Payment/Services/PaymentService.cs
+++ b/src/Modules/OrchardCore.Commerce.Payment/Services/PaymentService.cs
@@ -237,8 +237,11 @@ public class PaymentService : IPaymentService
                 orderPart.ShippingAddress = orderPart.BillingAddress;
             }
 
-            await _orderEvents.AwaitEachAsync(orderEvents =>
+            if (mustBeFree)
+            {
+                await _orderEvents.AwaitEachAsync(orderEvents =>
                 orderEvents.CreatedFreeAsync(orderPart, cart, cartViewModel));
+            }
         });
 
         await _contentManager.CreateAsync(order);


### PR DESCRIPTION
fix #597 