### PR TITLE
Make it possible to template a liquid PriceField Alternate from the web editor

### DIFF
--- a/src/Modules/OrchardCore.Commerce.ContentFields/Startup.cs
+++ b/src/Modules/OrchardCore.Commerce.ContentFields/Startup.cs
@@ -27,7 +27,8 @@ public class Startup : StartupBase
         services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
         services.AddScoped<IFieldsOnlyDisplayManager, FieldsOnlyDisplayManager>();
 
-        services.Configure<TemplateOptions>(option => {
+        services.Configure<TemplateOptions>(option =>
+        {
             option.MemberAccessStrategy.Register<PriceField>();
             option.MemberAccessStrategy.Register<PriceFieldDisplayViewModel>();
         });


### PR DESCRIPTION
Added registration for PriceFieldDisplayViewModel so it's possible to template a liquid PriceField Alternate from the web editor.